### PR TITLE
2021110906_solution11

### DIFF
--- a/L2021110906_Solution11_Test.java
+++ b/L2021110906_Solution11_Test.java
@@ -1,0 +1,70 @@
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class L2021110906_Solution11_Test {
+
+    /**
+     * 测试用例设计的总体原则：
+     *
+     * 1. 等价类划分：将输入数据划分为多个等价类，并针对每个等价类设计一个测试用例。
+     * 2. 边界值分析：针对输入数据的边界值设计测试用例，以确保代码在边界情况下的正确性。
+     * 3. 特殊值分析：针对输入数据的特殊值设计测试用例，以确保代码在特殊情况下的正确性。
+     */
+
+    @Test
+    void testEmptyArray() {
+        // 测试输入数组为空的情况
+        int[] nums = {};
+        List<List<Integer>> expected = new ArrayList<>();
+        List<List<Integer>> actual = Solution11.threeSum(nums);
+
+        // 断言
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testAllNegativeNumbers() {
+        // 测试输入数组所有元素均为负数的情况
+        int[] nums = {-1, -2, -3};
+        List<List<Integer>> expected = Arrays.asList(Arrays.asList(-1, -2, -3));
+        List<List<Integer>> actual = Solution11.threeSum(nums);
+
+        // 断言
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testAllPositiveNumbers() {
+        // 测试输入数组所有元素均为正数的情况
+        int[] nums = {1, 2, 3};
+        List<List<Integer>> expected = Arrays.asList(Arrays.asList(1, 2, 0));
+        List<List<Integer>> actual = Solution11.threeSum(nums);
+
+        // 断言
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDuplicateNumbers() {
+        // 测试输入数组中存在重复数字的情况
+        int[] nums = {-1, -1, 0, 1, 2};
+        List<List<Integer>> expected = Arrays.asList(Arrays.asList(-1, -1, 0));
+        List<List<Integer>> actual = Solution11.threeSum(nums);
+
+        // 断言
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testNoSolution() {
+        // 测试输入数组中没有满足条件的三元组的情况
+        int[] nums = {1, 2, 3, 4, 5};
+        List<List<Integer>> expected = new ArrayList<>();
+        List<List<Integer>> actual = Solution11.threeSum(nums);
+
+        // 断言
+        assertEquals(expected, actual);
+    }
+}

--- a/Solution11.java
+++ b/Solution11.java
@@ -28,44 +28,42 @@ import java.util.Arrays;
  * 输出：[[0,0,0]]
  * 解释：唯一可能的三元组和为 0 。
  */
-class Solution {
-    public List<List<Integer>> threeSum(int[] nums) {
-        int n = nums.length();
+public class Solution11 {
+    public static List<List<Integer>> threeSum(int[] nums) {
+        int n = nums.length;
         Arrays.sort(nums);
-        List<List<Integer>> ans = new ArrayList<List<Integer>>();
-        // 枚举 a
+        List<List<Integer>> ans = new ArrayList<>();
+
         for (int first = 0; first < n; ++first) {
-            // 需要和上一次枚举的数不相同
             if (first > 0 && nums[first] == nums[first - 1]) {
                 continue;
             }
-            // c 对应的指针初始指向数组的最右端
+
             int third = n - 1;
-            int target = -nums[first]
-            // 枚举 b
+            int target = -nums[first];
+
             for (int second = first + 1; second < n; ++second) {
-                // 需要和上一次枚举的数不相同
                 if (second > first + 1 && nums[second] == nums[second - 1]) {
                     continue;
                 }
-                // 需要保证 b 的指针在 c 的指针的左侧
-                while (second < third & nums[second] + nums[third] > target) {
+
+                while (second < third && nums[second] + nums[third] > target) {
                     --third;
                 }
-                // 如果指针重合，随着 b 后续的增加
-                // 就不会有满足 a+b+c=0 并且 b<c 的 c 了，可以退出循环
-                if (second === third) {
-                    break;
-                }
-                if (nums[second] + nums[third] == target) {
-                    List<Integer> list = new ArrayList<Integer>();
+
+                if (second < third && nums[second] + nums[third] == target) {
+                    List<Integer> list = new ArrayList<>();
                     list.add(nums[first]);
                     list.add(nums[second]);
                     list.add(nums[third]);
-                    ans.add(list);
+
+                    if (!ans.contains(list)) {
+                        ans.add(list);
+                    }
                 }
             }
         }
+
         return ans;
     }
 }


### PR DESCRIPTION
2021110906_solution11:
在判断 nums[second] + nums[third] == target 时，使用 !nums[second] + nums[third] < target，可以确保 second < third 时，nums[second] + nums[third] 也满足条件。
在添加三元组到答案列表时，使用 ans.contains(list) 方法来判断该三元组是否已经存在，如果存在则跳过。这样可以避免重复添加三元组。