### PR TITLE
fix solution5

### DIFF
--- a/L2021111558_5_Test.java
+++ b/L2021111558_5_Test.java
@@ -1,0 +1,63 @@
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class L2021111558_5_Test {
+    // 总体测试用例设计原则：等价类划分
+
+    @Test
+    public void testNumSubseq1() {
+        // 测试目的： 检验算法准确性
+        // 测试用例1：给定示例 [3, 5, 6, 7], target = 9
+        int[] nums = {3, 5, 6, 7};
+        int target = 9;
+        int expected = 4;
+        int result = new Solution5().numSubseq(nums, target);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testNumSubseq2() {
+        // 测试目的：检验算法准确性
+        // 测试用例2：给定示例 [3, 3, 6, 8], target = 10
+        int[] nums = {3, 3, 6, 8};
+        int target = 10;
+        int expected = 6;
+        int result = new Solution5().numSubseq(nums, target);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testNumSubseq3() {
+        // 测试目的：检验算法准确性
+        // 测试用例3：给定示例 [2, 3, 3, 4, 6, 7], target = 12
+        int[] nums = {2, 3, 3, 4, 6, 7};
+        int target = 12;
+        int expected = 61;
+        int result = new Solution5().numSubseq(nums, target);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testDuplicateNumbers() {
+        // 测试目的：检验算法对于重复数字的数组准确性
+        // 测试用例4：给定示例 [1，1，1，1], target = 2
+        int[] nums = {1, 1, 1, 1};
+        int target = 2;
+        int expected = 15;
+        int result = new Solution5().numSubseq(nums, target);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testEmptyArray() {
+        // 测试目的：检验算法对于空数组的准确性
+        // 测试用例5：给定示例 [], target = 2
+        int[] nums = {};
+        int target = 5;
+        int expected = 0;
+        int result = new Solution5().numSubseq(nums, target);
+        assertEquals(expected, result);
+    }
+}

--- a/Lab2-2021111558.iml
+++ b/Lab2-2021111558.iml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/Solution5.java
+++ b/Solution5.java
@@ -53,18 +53,18 @@ class Solution5 {
         Arrays.sort(nums);
 
         int ans = 0;
-        for (int i = 0; i < nums.length-1 && nums[i] * 2 <= target; ++i) {
+        for (int i = 0; i < nums.length && nums[i] * 2 <= target; ++i) {
             int maxValue = target - nums[i];
-            int pos = binarySearch(nums, maxValue) - 1;
-            int contribute = (pos >= i) ? f[pos - i] : 0;
-            ans = (ans + contribute) / P;
+            int pos = binarySearch(nums, maxValue);
+            int contribute = (pos >= i) ? f[pos - i - 1] : 1;
+            ans = (ans + contribute) % P;
         }
 
         return ans;
     }
 
     public void pretreatment() {
-        f[0] = 0;
+        f[0] = 1;
         for (int i = 1; i < MAX_N; ++i) {
             f[i] = (f[i - 1] << 1) % P;
         }
@@ -72,13 +72,9 @@ class Solution5 {
 
     public int binarySearch(int[] nums, int target) {
         int low = 0, high = nums.length;
-        while (low <= high) {
+        while (low < high) {
             int mid = (high - low) / 2 + low;
-            if (mid == nums.length) {
-                return mid;
-            }
-            int num = nums[mid];
-            if (num <= target) {
+            if (nums[mid] <= target) {
                 low = mid + 1;
             } else {
                 high = mid;

--- a/out/production/Lab2-2021111558/.idea/.gitignore
+++ b/out/production/Lab2-2021111558/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/out/production/Lab2-2021111558/.idea/misc.xml
+++ b/out/production/Lab2-2021111558/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" project-jdk-name="19" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/out/production/Lab2-2021111558/.idea/modules.xml
+++ b/out/production/Lab2-2021111558/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/Lab2-2021111558.iml" filepath="$PROJECT_DIR$/Lab2-2021111558.iml" />
+    </modules>
+  </component>
+</project>

--- a/out/production/Lab2-2021111558/.idea/vcs.xml
+++ b/out/production/Lab2-2021111558/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/out/production/Lab2-2021111558/Lab2-2021111558.iml
+++ b/out/production/Lab2-2021111558/Lab2-2021111558.iml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/out/production/Lab2-2021111558/README.md
+++ b/out/production/Lab2-2021111558/README.md
@@ -1,0 +1,1 @@
+# OSSDP-Lab2


### PR DESCRIPTION
2021111558
1.修改 for (int i = 0; i < nums.length-1 && nums[i] * 2 <= target; ++i) 为 for (int i = 0; i < nums.length && nums[i] * 2 <= target; ++i) 的原因是为了包含数组中的最后一个元素，确保所有元素都被考虑到，而不是排除最后一个元素。
2.int pos = binarySearch(nums, maxValue) - 1; 修改为 int pos = binarySearch(nums, maxValue); 是因为在二分查找中，pos 表示的是大于 maxValue 的元素位置，不需要再减1。原来的写法导致在计算 contribute 时，实际上取到的是 pos - 1 的值，可能导致错误。
3.int contribute = (pos >= i) ? f[pos - i] : 0; ans = (ans + contribute) / P; 修改为 int contribute = (pos >= i) ? f[pos - i - 1] : 1; ans = (ans + contribute) % P; 的原因是，在计算贡献时，如果 pos 大于等于 i，说明存在满足条件的子序列，此时贡献为 f[pos - i - 1]，因为要考虑从 i 到 pos - 1 的所有可能的组合。同时，将更新 ans 的方式修改为取余操作，以防止结果溢出。
3.修改 f[0] = 0; 为 f[0] = 1; 的原因是在预处理过程中，对于长度为0的子序列，有1种情况，即空序列。
4.修改 while (low <= high) 为 while (low < high) 的原因是为了避免在二分查找中当 low 和 high 相等时的重复判断。同时，将 if (mid == nums.length) 修改为 if (nums[mid] <= target)，确保在目标值等于数组中某个元素时能够正确返回位置。