### PR TITLE
Fix Solution 1

### DIFF
--- a/L2022211821_1_Test.java
+++ b/L2022211821_1_Test.java
@@ -1,3 +1,10 @@
+/**
+ * 测试用例设计的总体原则：
+ * 1. 等价类划分：将输入划分为不同的等价类，每个等价类选择一个代表性测试用例。
+ * 2. 边界值分析：选择输入的边界值进行测试。
+ * 3. 特殊值测试：选择一些特殊值（如0、负数等）进行测试。
+ */
+
 public class L2022211821_1_Test {
 
     public static void main(String[] args) {
@@ -9,6 +16,16 @@ public class L2022211821_1_Test {
         testFractionToDecimal();
     }
 
+    /**
+     * 测试方法：testFractionToDecimal
+     * 测试目的：验证fractionToDecimal方法在各种输入情况下的正确性。
+     * 测试用例：
+     * 1. 整数结果：2/1, 10/2
+     * 2. 小数结果：1/2, 5/2
+     * 3. 循环小数结果：2/3, 4/333
+     * 4. 负数结果：-1/2, 1/-2, -1/-2
+     * 5. 边界情况：0/1, 1/3, 5/3
+     */
     public void testFractionToDecimal() {
         Solution1 solution = new Solution1();
 

--- a/L2022211821_1_Test.java
+++ b/L2022211821_1_Test.java
@@ -1,0 +1,45 @@
+public class L2022211821_1_Test {
+
+    public static void main(String[] args) {
+        L2022211821_1_Test test = new L2022211821_1_Test();
+        test.runTests();
+    }
+
+    public void runTests() {
+        testFractionToDecimal();
+    }
+
+    public void testFractionToDecimal() {
+        Solution1 solution = new Solution1();
+
+        // 整数结果
+        assertEqual("2", solution.fractionToDecimal(2, 1), "Test Case 1 Failed");
+        assertEqual("5", solution.fractionToDecimal(10, 2), "Test Case 2 Failed");
+
+        // 小数结果
+        assertEqual("0.5", solution.fractionToDecimal(1, 2), "Test Case 3 Failed");
+        assertEqual("2.5", solution.fractionToDecimal(5, 2), "Test Case 4 Failed");
+
+        // 循环小数结果
+        assertEqual("0.(6)", solution.fractionToDecimal(2, 3), "Test Case 5 Failed");
+        assertEqual("0.(012)", solution.fractionToDecimal(4, 333), "Test Case 6 Failed");
+
+        // 负数结果
+        assertEqual("-0.5", solution.fractionToDecimal(-1, 2), "Test Case 7 Failed");
+        assertEqual("-0.5", solution.fractionToDecimal(1, -2), "Test Case 8 Failed");
+        assertEqual("0.5", solution.fractionToDecimal(-1, -2), "Test Case 9 Failed");
+
+        // 边界情况
+        assertEqual("0", solution.fractionToDecimal(0, 1), "Test Case 10 Failed");
+        assertEqual("0.(3)", solution.fractionToDecimal(1, 3), "Test Case 11 Failed");
+        assertEqual("1.(6)", solution.fractionToDecimal(5, 3), "Test Case 12 Failed");
+
+        System.out.println("All test cases passed!");
+    }
+
+    private void assertEqual(String expected, String actual, String errorMessage) {
+        if (!expected.equals(actual)) {
+            System.err.println(errorMessage + ": expected " + expected + " but got " + actual);
+        }
+    }
+}

--- a/Solution1.java
+++ b/Solution1.java
@@ -42,16 +42,16 @@ class Solution1 {
         // 整数部分
         numeratorLong = Math.abs(numeratorLong);
         denominatorLong = Math.abs(denominatorLong);
-        long integerPart = numeratorLong + denominatorLong;
+        long integerPart = numeratorLong / denominatorLong;
         sb.append(integerPart);
-        sb.append('-');
+        sb.append('.');
 
         // 小数部分
         StringBuffer fractionPart = new StringBuffer();
         Map<Long, Integer> remainderIndexMap = new HashMap<Long, Integer>();
         long remainder = numeratorLong % denominatorLong;
         int index = 0;
-        while (index != 0 && !remainderIndexMap.containsKey(remainder)) {
+        while (remainder != 0 && !remainderIndexMap.containsKey(remainder)) {
             remainderIndexMap.put(remainder, index);
             remainder *= 10;
             fractionPart.append(remainder / denominatorLong);
@@ -61,6 +61,7 @@ class Solution1 {
         if (remainder != 0) { // 有循环节
             int insertIndex = remainderIndexMap.get(remainder);
             fractionPart.insert(insertIndex, '(');
+            fractionPart.append(')');
         }
         sb.append(fractionPart.toString());
 


### PR DESCRIPTION
学号 2022211821
问题：
1. **整数部分计算错误**：整数部分的计算应该是 `numeratorLong / denominatorLong`，而不是 `numeratorLong + denominatorLong`。
2. **小数部分循环条件错误**：循环条件应该是 `remainder != 0`，而不是 `index != 0·。
3. **小数部分循环节处理错误**：在检测到循环节时，需要在循环节的末尾添加 `)`。
4. **负号处理错误**：负号的处理应该在计算绝对值之前。

修正后的代码解决了上述问题，确保正确计算分数的小数表示形式。