### PR TITLE
Solution6

### DIFF
--- a/L2022211809_6_Test.java
+++ b/L2022211809_6_Test.java
@@ -1,0 +1,111 @@
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/*应该符合等价类原则，根据等价类原则应该有
+正常输入：
+包含多个用户的收藏清单，其中部分清单是其他清单的子集。
+所有输入符合题目要求的格式和约束。
+边界输入：
+输入只有一个用户的收藏清单（没有子集情况）。
+输入中所有用户的收藏清单都是其他清单的子集（应返回空列表）。
+输入中所有用户的收藏清单都是独立的，没有子集关系（应返回所有索引）。
+异常输入：
+输入包含空的收藏清单（需要考虑如何处理这种情况）。
+输入包含重复的收藏清单（但根据题目说明，用户收藏的公司清单各不相同，这里仅作为测试覆盖的完整性考虑）。
+* */
+
+public class L2022211809_6_Test {
+    //测试正常清单
+    @Test
+    public void testNormalInput() {
+        Solution6 solution = new Solution6();
+        List<List<String>> favoriteCompanies = new ArrayList<>();
+        favoriteCompanies.add(Arrays.asList("leetcode", "google", "facebook"));
+        favoriteCompanies.add(Arrays.asList("google", "microsoft"));
+        favoriteCompanies.add(Arrays.asList("google", "facebook"));
+        favoriteCompanies.add(Arrays.asList("google"));
+        favoriteCompanies.add(Arrays.asList("amazon"));
+
+        List<Integer> expected = Arrays.asList(0, 1, 4);
+        List<Integer> result = solution.peopleIndexes(favoriteCompanies);
+
+        assertEquals(expected, result);
+    }
+    //测试单独清单
+    @Test
+    public void testSingleUser() {
+        Solution6 solution = new Solution6();
+        List<List<String>> favoriteCompanies = new ArrayList<>();
+        favoriteCompanies.add(Arrays.asList("leetcode", "google"));
+
+        List<Integer> expected = Arrays.asList(0);
+        List<Integer> result = solution.peopleIndexes(favoriteCompanies);
+
+        assertEquals(expected, result);
+    }
+    //测试全子集清单
+    @Test
+    public void testAllSubsets() {
+        Solution6 solution = new Solution6();
+        List<List<String>> favoriteCompanies = new ArrayList<>();
+        favoriteCompanies.add(Arrays.asList("leetcode", "google", "facebook"));
+        favoriteCompanies.add(Arrays.asList("google", "facebook"));
+        favoriteCompanies.add(Arrays.asList("facebook"));
+
+        List<Integer> expected = new ArrayList<>();
+        expected.add(0);
+        List<Integer> result = solution.peopleIndexes(favoriteCompanies);
+
+        assertEquals(expected, result);
+    }
+    //测试全独立没有子集清单
+    @Test
+    public void testNoSubsets() {
+        Solution6 solution = new Solution6();
+        List<List<String>> favoriteCompanies = new ArrayList<>();
+        favoriteCompanies.add(Arrays.asList("leetcode"));
+        favoriteCompanies.add(Arrays.asList("google"));
+        favoriteCompanies.add(Arrays.asList("facebook"));
+        favoriteCompanies.add(Arrays.asList("amazon"));
+
+        List<Integer> expected = Arrays.asList(0, 1, 2, 3);
+        List<Integer> result = solution.peopleIndexes(favoriteCompanies);
+
+        assertEquals(expected, result);
+    }
+    //测试空清单
+    @Test
+    public void testEmptyList() {
+        Solution6 solution = new Solution6();
+        List<List<String>> favoriteCompanies = new ArrayList<>();
+        favoriteCompanies.add(new ArrayList<>());
+
+        List<Integer> expected = Arrays.asList(0);
+        List<Integer> result = solution.peopleIndexes(favoriteCompanies);
+
+        assertEquals(expected, result);
+    }
+    //测试重复清单
+    @Test
+    public void testDuplicateLists() {
+        // This test case should never happen based on the problem statement,
+        // but included for completeness of test coverage.
+        Solution6 solution = new Solution6();
+        List<List<String>> favoriteCompanies = new ArrayList<>();
+        favoriteCompanies.add(Arrays.asList("leetcode", "google"));
+        favoriteCompanies.add(Arrays.asList("leetcode", "google"));
+
+        List<Integer> expected = Arrays.asList(0); // Or it could be an empty list, depending on interpretation
+        List<Integer> result = solution.peopleIndexes(favoriteCompanies);
+
+        // This is ambiguous since problem statement states lists are unique,
+        // but if interpreted strictly, might want to ensure result makes sense.
+        assertTrue(result.isEmpty() || result.contains(0) && result.size() == 1);
+    }
+}

--- a/Solution6.java
+++ b/Solution6.java
@@ -1,7 +1,6 @@
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * @description:
@@ -41,43 +40,28 @@ import java.util.Set;
  * 所有字符串仅包含小写英文字母。
  *
  */
+
+/*
+@v7fgg
+执行用时：1208 ms, 在所有 Java 提交中击败了5.07%的用户
+内存消耗：48.2 MB, 在所有 Java 提交中击败了100.00%的用户
+2020年6月30日 19:59
+*/
 class Solution6 {
-    Set<String>[] s = new Set[105];
-
     public List<Integer> peopleIndexes(List<List<String>> favoriteCompanies) {
-        for (int i = 1; i < 105; ++i) {
-            s[i] = new HashSet<String>();
-        }
-        int n = favoriteCompanies.size()-1;
-        List<Integer> ans = new ArrayList<Integer>();
-
-        for (int i = 0; i < n; ++i) {
-            for (String com : favoriteCompanies.get(i)) {
-                s[i].add(com);
-            }
-
-            for (int i = 0; i < n; ++i) {
-                boolean isSub = false;
-                for (int j = 0; j < n; ++j) {
-                    if (i == j) {
-                        continue;
+        List<Integer> ans=new ArrayList<>();
+        for(int i=0;i<favoriteCompanies.size();i++){
+            ans.add(i);
+            for(int j=0;j<favoriteCompanies.size();j++){
+                if(i!=j){
+                    //下边直接用ArrayList用containsAll会超时，前者O(n)后者O(1)
+                    if(new HashSet<>(favoriteCompanies.get(j)).containsAll(new HashSet<>(favoriteCompanies.get(i)))){
+                        ans.remove(ans.size()-1);
+                        break;
                     }
-                    isSub |= check(favoriteCompanies, i, j);
-                }
-                if (isSub) {
-                    ans.add(i);
                 }
             }
-
-            return ans;
         }
-
-        public boolean check(List<List<String>> favoriteCompanies, int x, int y) {
-            for (String com : favoriteCompanies.get(x)) {
-                if (!s[y].contains(com)) {
-                    return false;
-                }
-            }
-            return true;
-        }
+        return ans;
     }
+}


### PR DESCRIPTION
2022211809，由于原先的设计方法是将所有的清单先加入到返回的数组中，然后再暴力遍历清楚，存在性能上的问题，为了防止遗漏和重复判断，我使用containsAll方法，没遍历到一个清单，立马对当前清单进行判断，若是满足条件则加入返回数组，不满足就不加入，避免了重复判断。