### PR TITLE
Solution7

### DIFF
--- a/L2022211870_7_Test.java
+++ b/L2022211870_7_Test.java
@@ -1,0 +1,51 @@
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class L2022211870_7_Test {
+
+    /**
+     * 测试用例设计总体原则：
+     * 1. 等价类划分：考虑正常输入、边界情况和特殊输入。
+     * 2. 边界条件：测试字符串长度为 1、2、最大值等情况。
+     * 3. 特殊情况：处理没有可交换对、所有字符相同等情况。
+     */
+
+    @Test
+    public void testSmallestStringWithSwaps() {
+        Solution7 solution = new Solution7();
+
+        // 测试用例 1: 正常情况
+        String s1 = "dcab";
+        List<List<Integer>> pairs1 = Arrays.asList(Arrays.asList(0, 3), Arrays.asList(1, 2));
+        assertEquals("bacd", solution.smallestStringWithSwaps(s1, pairs1));
+
+        // 测试用例 2: 多次交换
+        String s2 = "dcab";
+        List<List<Integer>> pairs2 = Arrays.asList(Arrays.asList(0, 3), Arrays.asList(1, 2), Arrays.asList(0, 2));
+        assertEquals("abcd", solution.smallestStringWithSwaps(s2, pairs2));
+
+        // 测试用例 3: 所有字符相同
+        String s3 = "aaaa";
+        List<List<Integer>> pairs3 = Arrays.asList(Arrays.asList(0, 1), Arrays.asList(1, 2));
+        assertEquals("aaaa", solution.smallestStringWithSwaps(s3, pairs3));
+
+        // 测试用例 4: 没有可交换对
+        String s4 = "dcab";
+        List<List<Integer>> pairs4 = Arrays.asList();
+        assertEquals("dcab", solution.smallestStringWithSwaps(s4, pairs4));
+
+        // 测试用例 5: 边界条件，字符串长度为 1
+        String s5 = "a";
+        List<List<Integer>> pairs5 = Arrays.asList();
+        assertEquals("a", solution.smallestStringWithSwaps(s5, pairs5));
+
+        // 测试用例 6: 边界条件，字符串长度为 2
+        String s6 = "ab";
+        List<List<Integer>> pairs6 = Arrays.asList(Arrays.asList(0, 1));
+        assertEquals("ab", solution.smallestStringWithSwaps(s6, pairs6));
+    }
+}

--- a/Solution7.java
+++ b/Solution7.java
@@ -50,14 +50,13 @@ import java.util.PriorityQueue;
 public class Solution7 {
 
     public String smallestStringWithSwaps(String s, List<List<Integer>> pairs) {
-
-        if (pairs.size() <= 1) {
-            return s;
+        if (pairs.isEmpty()) {
+            return s; // 如果没有可交换的索引对，直接返回原字符串
         }
 
-        // 第 1 步：将任意交换的结点对输入并查集
+        // 第 1 步：构建并查集
         int len = s.length();
-        UnionFind unionFind = new UnionFind(len-1);
+        UnionFind unionFind = new UnionFind(len);
         for (List<Integer> pair : pairs) {
             int index1 = pair.get(0);
             int index2 = pair.get(1);
@@ -66,36 +65,33 @@ public class Solution7 {
 
         // 第 2 步：构建映射关系
         char[] charArray = s.toCharArray();
-        // key：连通分量的代表元，value：同一个连通分量的字符集合（保存在一个优先队列中）
-        Map<Integer, PriorityQueue<Character>> hashMap = new HashMap<>(len);
-        for (int i = 0; i < len; i++)
+        Map<Integer, PriorityQueue<Character>> hashMap = new HashMap<>();
+        for (int i = 0; i < len; i++) {
             int root = unionFind.find(i);
+            // 将同一连通分量的字符放入优先队列中
             hashMap.computeIfAbsent(root, key -> new PriorityQueue<>()).offer(charArray[i]);
+        }
 
         // 第 3 步：重组字符串
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < len; i++) {
             int root = unionFind.find(i);
+            // 从优先队列中取出最小的字符
             stringBuilder.append(hashMap.get(root).poll());
-            stringBuilder.append(" ");
         }
         return stringBuilder.toString();
     }
 
     private class UnionFind {
-
         private int[] parent;
-        /**
-         * 以 i 为根结点的子树的高度（引入了路径压缩以后该定义并不准确）
-         */
         private int[] rank;
 
         public UnionFind(int n) {
             this.parent = new int[n];
             this.rank = new int[n];
             for (int i = 0; i < n; i++) {
-                this.parent[i] = i;
-                this.rank[i] = 1;
+                this.parent[i] = i; // 每个节点的父节点初始为自己
+                this.rank[i] = 1; // 初始高度为 1
             }
         }
 
@@ -103,25 +99,23 @@ public class Solution7 {
             int rootX = find(x);
             int rootY = find(y);
             if (rootX == rootY) {
-                return;
+                return; // 如果已经在同一个集合中，则不合并
             }
 
-            if (rank[rootX] == rank[rootY]) {
-                parent[rootX] = rootY;
-                // 此时以 rootY 为根结点的树的高度仅加了 1
-                rank[rootY]++;
-            } else if (rank[rootX] < rank[rootY]) {
-                parent[rootX] = rootY;
-                // 此时以 rootY 为根结点的树的高度不变
+            // 合并时根据 rank 更新
+            if (rank[rootX] < rank[rootY]) {
+                parent[rootX] = rootY; // 让 rootX 指向 rootY
+            } else if (rank[rootX] > rank[rootY]) {
+                parent[rootY] = rootX; // 让 rootY 指向 rootX
             } else {
-                // 同理，此时以 rootX 为根结点的树的高度不变
-                parent[rootY] = rootX;
+                parent[rootY] = rootX; // 让 rootY 指向 rootX
+                rank[rootX]++; // 增加 rootX 的高度
             }
         }
 
         public int find(int x) {
             if (x != parent[x]) {
-                parent[x] = find(parent[x]);
+                parent[x] = find(parent[x]); // 路径压缩
             }
             return parent[x];
         }

--- a/Solution7.java
+++ b/Solution7.java
@@ -47,16 +47,18 @@ import java.util.PriorityQueue;
  *
  */
 
+
 public class Solution7 {
 
     public String smallestStringWithSwaps(String s, List<List<Integer>> pairs) {
-        if (pairs.isEmpty()) {
-            return s; // 如果没有可交换的索引对，直接返回原字符串
+
+        if (pairs.size() <= 1) {
+            return s;
         }
 
-        // 第 1 步：构建并查集
+        // 第 1 步：将任意交换的结点对输入并查集
         int len = s.length();
-        UnionFind unionFind = new UnionFind(len);
+        UnionFind unionFind = new UnionFind(len);  // 修正为len
         for (List<Integer> pair : pairs) {
             int index1 = pair.get(0);
             int index2 = pair.get(1);
@@ -65,10 +67,10 @@ public class Solution7 {
 
         // 第 2 步：构建映射关系
         char[] charArray = s.toCharArray();
-        Map<Integer, PriorityQueue<Character>> hashMap = new HashMap<>();
+        // key：连通分量的代表元，value：同一个连通分量的字符集合（保存在一个优先队列中）
+        Map<Integer, PriorityQueue<Character>> hashMap = new HashMap<>(len);
         for (int i = 0; i < len; i++) {
             int root = unionFind.find(i);
-            // 将同一连通分量的字符放入优先队列中
             hashMap.computeIfAbsent(root, key -> new PriorityQueue<>()).offer(charArray[i]);
         }
 
@@ -76,22 +78,22 @@ public class Solution7 {
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < len; i++) {
             int root = unionFind.find(i);
-            // 从优先队列中取出最小的字符
-            stringBuilder.append(hashMap.get(root).poll());
+            stringBuilder.append(hashMap.get(root).poll());  // 不再附加空格
         }
         return stringBuilder.toString();
     }
 
     private class UnionFind {
+
         private int[] parent;
         private int[] rank;
 
         public UnionFind(int n) {
-            this.parent = new int[n];
+            this.parent = new int[n];  // 修正为n
             this.rank = new int[n];
             for (int i = 0; i < n; i++) {
-                this.parent[i] = i; // 每个节点的父节点初始为自己
-                this.rank[i] = 1; // 初始高度为 1
+                this.parent[i] = i;
+                this.rank[i] = 1;
             }
         }
 
@@ -99,25 +101,25 @@ public class Solution7 {
             int rootX = find(x);
             int rootY = find(y);
             if (rootX == rootY) {
-                return; // 如果已经在同一个集合中，则不合并
+                return;
             }
 
-            // 合并时根据 rank 更新
-            if (rank[rootX] < rank[rootY]) {
-                parent[rootX] = rootY; // 让 rootX 指向 rootY
-            } else if (rank[rootX] > rank[rootY]) {
-                parent[rootY] = rootX; // 让 rootY 指向 rootX
+            if (rank[rootX] == rank[rootY]) {
+                parent[rootX] = rootY;
+                rank[rootY]++;
+            } else if (rank[rootX] < rank[rootY]) {
+                parent[rootX] = rootY;
             } else {
-                parent[rootY] = rootX; // 让 rootY 指向 rootX
-                rank[rootX]++; // 增加 rootX 的高度
+                parent[rootY] = rootX;
             }
         }
 
         public int find(int x) {
             if (x != parent[x]) {
-                parent[x] = find(parent[x]); // 路径压缩
+                parent[x] = find(parent[x]);
             }
             return parent[x];
         }
     }
 }
+


### PR DESCRIPTION
2022211870
1. 并查集初始化错误
在代码中，并查集的 UnionFind 初始化参数是 len-1，这是错误的，因为并查集需要处理整个字符串的索引范围，应该使用 len 来初始化。
2. 字符交换部分逻辑错误
在代码中，处理字符串字符时，使用了 PriorityQueue 来存储字符，这部分逻辑是正确的，但在使用 hashMap.computeIfAbsent 方法时，缺少大括号 {}，导致代码块无法正确执行。应该为 for 循环中的代码加上大括号。
3. 返回结果拼接错误
stringBuilder.append(" ");不需要在每个字符后面加空格，只需直接拼接字符即可。
4. 并查集的数组初始化有问题
在 UnionFind 的构造函数中，parent 和 rank 数组的初始化长度应该是 n，而不是 n-1。此外，数组的索引应从 0 到 n-1。