### PR TITLE
Solution7 Fix

### DIFF
--- a/L2022211878_7_Test.java
+++ b/L2022211878_7_Test.java
@@ -1,0 +1,71 @@
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * 等价类划分原则：
+ * 单字符字符串：当输入字符串只有一个字符时。
+ * 多字符字符串：当输入字符串有多个字符时。
+ * 无交换对：当没有提供任何索引对时。
+ * 一个交换对：当只提供了一个索引对时。
+ * 多个交换对：当提供了多个索引对时。
+ * 重复交换对：当提供了重复索引对时。
+ */
+
+public class L2022211878_7_Test {
+
+    //单字符字符串 无交换对
+    @Test
+    public void testSingleCharacter() {
+        Solution7 solution = new Solution7();
+        String s = "a";
+        List<List<Integer>> pairs = new ArrayList<>();
+        assertEquals("a", solution.smallestStringWithSwaps(s, pairs));
+    }
+    //多字符字符串 无交换对
+    @Test
+    public void testNoPairs() {
+        Solution7 solution = new Solution7();
+        String s = "dcab";
+        List<List<Integer>> pairs = new ArrayList<>();
+        assertEquals("dcab", solution.smallestStringWithSwaps(s, pairs));
+    }
+    //多字符字符串 一个交换对
+    @Test
+    public void testOnePair() {
+        Solution7 solution = new Solution7();
+        String s = "dcab";
+        List<List<Integer>> pairs = new ArrayList<>(Arrays.asList(
+                Arrays.asList(0, 3)
+        ));
+        assertEquals("bcad", solution.smallestStringWithSwaps(s, pairs));
+    }
+    //多字符字符串 多个交换对
+    @Test
+    public void testMultiplePairs() {
+        Solution7 solution = new Solution7();
+        String s = "dcab";
+        List<List<Integer>> pairs = new ArrayList<>(Arrays.asList(
+                Arrays.asList(0, 3),
+                Arrays.asList(1, 2)
+        ));
+        assertEquals("bacd", solution.smallestStringWithSwaps(s, pairs));
+    }
+    //重复的交换对
+    @Test
+    public void testDuplicatePairs() {
+        Solution7 solution = new Solution7();
+        String s = "dcab";
+        List<List<Integer>> pairs = new ArrayList<>(Arrays.asList(
+                Arrays.asList(0, 3),
+                Arrays.asList(1, 2),
+                Arrays.asList(0, 3)  // 重复的交换对
+        ));
+        assertEquals("bacd", solution.smallestStringWithSwaps(s, pairs));
+    }
+
+}

--- a/Solution7.java
+++ b/Solution7.java
@@ -51,13 +51,14 @@ public class Solution7 {
 
     public String smallestStringWithSwaps(String s, List<List<Integer>> pairs) {
 
-        if (pairs.size() <= 1) {
+        int len = s.length();
+        if (pairs.size() == 0 || len <= 1) {
             return s;
         }
 
         // 第 1 步：将任意交换的结点对输入并查集
         int len = s.length();
-        UnionFind unionFind = new UnionFind(len-1);
+        UnionFind unionFind = new UnionFind(len);
         for (List<Integer> pair : pairs) {
             int index1 = pair.get(0);
             int index2 = pair.get(1);
@@ -77,7 +78,6 @@ public class Solution7 {
         for (int i = 0; i < len; i++) {
             int root = unionFind.find(i);
             stringBuilder.append(hashMap.get(root).poll());
-            stringBuilder.append(" ");
         }
         return stringBuilder.toString();
     }

--- a/Solution7.java
+++ b/Solution7.java
@@ -57,7 +57,6 @@ public class Solution7 {
         }
 
         // 第 1 步：将任意交换的结点对输入并查集
-        int len = s.length();
         UnionFind unionFind = new UnionFind(len);
         for (List<Integer> pair : pairs) {
             int index1 = pair.get(0);
@@ -69,10 +68,10 @@ public class Solution7 {
         char[] charArray = s.toCharArray();
         // key：连通分量的代表元，value：同一个连通分量的字符集合（保存在一个优先队列中）
         Map<Integer, PriorityQueue<Character>> hashMap = new HashMap<>(len);
-        for (int i = 0; i < len; i++)
+        for (int i = 0; i < len; i++){
             int root = unionFind.find(i);
             hashMap.computeIfAbsent(root, key -> new PriorityQueue<>()).offer(charArray[i]);
-
+	}
         // 第 3 步：重组字符串
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < len; i++) {


### PR DESCRIPTION
# Solution7 Fix

## 修改点

- 并查集的初始化：UnionFind 的构造函数应该接收字符串长度 len 作为参数，而不是 len-1。
- 重建字符串时的空格问题：在将字符添加到 StringBuilder 时，不需要添加额外的空格。
- For循环构建映射关系格式问题：没有用{}包括构建映射关系代码。

## 测试点

使用等价类划分原则

- 单字符字符串：当输入字符串只有一个字符时。
- 多字符字符串：当输入字符串有多个字符时。
- 无交换对：当没有提供任何索引对时。
- 一个交换对：当只提供了一个索引对时。
- 多个交换对：当提供了多个索引对时。
- 重复交换对：当提供了重复索引对时。

测试结果均通过