### PR TITLE
Solution2

### DIFF
--- a/L2022211933_2_Test.java
+++ b/L2022211933_2_Test.java
@@ -1,0 +1,38 @@
+package org.example;
+
+import org.junit.Test;
+//import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 单元测试类，用于测试 Solution 类的 removeDuplicateLetters 方法
+ * 测试用例设计原则：等价类划分
+ */
+public class L2022211933_2_Test {
+
+    /**
+     * 测试目的：测试对包含重复字母的字符串去重的情况
+     * 测试用例：输入包含重复字母的字符串，例如 "bcabc"，"cbacdcbc" 等
+     */
+    @Test
+    public void testRemoveDuplicateLettersWithDuplicates() {
+        Solution solution = new Solution();
+        String input1 = "bcabc";
+        String input2 = "cbacdcbc";
+        assertEquals("abc", solution.removeDuplicateLetters(input1));
+        assertEquals("acdb", solution.removeDuplicateLetters(input2));
+    }
+
+    /**
+     * 测试目的：测试对不包含重复字母的字符串处理的情况
+     * 测试用例：输入不包含重复字母的字符串，例如 "abcdef"，"xyzyx" 等
+     */
+    @Test
+    public void testRemoveDuplicateLettersWithoutDuplicates() {
+        Solution solution = new Solution();
+        String input1 = "abcdef";
+        String input2 = "xyzyx";
+        assertEquals("abcdef", solution.removeDuplicateLetters(input1));
+        assertEquals("xyz", solution.removeDuplicateLetters(input2));
+    }
+}

--- a/Solution2.java
+++ b/Solution2.java
@@ -18,16 +18,16 @@
  */
 class Solution2 {
     public String removeDuplicateLetters(String s) {
-        boolean[] vis = new boolean[25];
-        int[] num = new int[25];
+        boolean[] vis = new boolean[26];
+        int[] num = new int[26];
         for (int i = 0; i < s.length(); i++) {
-            num[s.charAt(i) - ' ']++;
+            num[s.charAt(i) - 'a']++;
         }
 
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < s.length()+1; i++) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
             char ch = s.charAt(i);
-            if (!vis[ch - ' ']) {
+            if (!vis[ch - 'a']) {
                 while (sb.length() > 0 && sb.charAt(sb.length() - 1) > ch) {
                     if (num[sb.charAt(sb.length() - 1) - 'a'] > 0) {
                         vis[sb.charAt(sb.length() - 1) - 'a'] = false;
@@ -39,7 +39,7 @@ class Solution2 {
                 vis[ch - 'a'] = true;
                 sb.append(ch);
             }
-            num[ch - 'a'] += 1;
+            num[ch - 'a'] -= 1;
         }
         return sb.toString();
     }


### PR DESCRIPTION
2022211933
布尔数组vis和计数数组num的长度应为26，而不是25。
在计算数组索引时，应使用字母'a'，而不是空格字符。
将StringBuffer替换为StringBuilder，因为在单线程环境下，StringBuilder的性能更好。
在第二个for循环中，循环的条件应为s.length()，而不是s.length()+1，以避免数组越界。
修改了num[ch - 'a'] += 1为num[ch - 'a'] -= 1，确保正确减少对应字母的数量。