### PR TITLE
fix solution5 and add tests

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/OSSDP-Lab2-fork-2022211857.iml
+++ b/.idea/OSSDP-Lab2-fork-2022211857.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="20" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/OSSDP-Lab2-fork-2022211857.iml" filepath="$PROJECT_DIR$/.idea/OSSDP-Lab2-fork-2022211857.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/L2022211857_5_Test.java
+++ b/L2022211857_5_Test.java
@@ -1,0 +1,43 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class L2022211857_5_Test {
+
+    @Test
+    public void testNumSubseqCase1() {
+        Solution5 solution = new Solution5();
+        int[] nums = {3, 5, 6, 7};
+        int target = 9;
+        int expected = 4;  // 预期结果为 4 个满足条件的子序列
+        assertEquals(expected, solution.numSubseq(nums, target));
+    }
+
+    @Test
+    public void testNumSubseqCase2() {
+        Solution5 solution = new Solution5();
+        int[] nums = {3, 3, 6, 8};
+        int target = 10;
+        int expected = 6;  // 预期结果为 6 个满足条件的子序列
+        assertEquals(expected, solution.numSubseq(nums, target));
+    }
+
+    @Test
+    public void testNumSubseqCase3() {
+        Solution5 solution = new Solution5();
+        int[] nums = {2, 3, 3, 4, 6, 7};
+        int target = 12;
+        int expected = 61;  // 预期结果为 61 个满足条件的子序列
+        assertEquals(expected, solution.numSubseq(nums, target));
+    }
+
+    @Test
+    public void testNumSubseqEmptyArray() {
+        Solution5 solution = new Solution5();
+        int[] nums = {};
+        int target = 10;
+        int expected = 0;  // 空数组应返回 0
+        assertEquals(expected, solution.numSubseq(nums, target));
+    }
+
+
+}

--- a/Solution5.java
+++ b/Solution5.java
@@ -1,46 +1,5 @@
 import java.util.Arrays;
 
-/**
- * @description:
- *
- * 给你一个整数数组 nums 和一个整数 target 。
- *
- * 请你统计并返回 nums 中能满足其最小元素与最大元素的 和 小于或等于 target 的 非空 子序列的数目。
- *
- * 由于答案可能很大，请将结果对 109 + 7 取余后返回。
- *
- *
- *
- * 示例 1：
- *
- * 输入：nums = [3,5,6,7], target = 9
- * 输出：4
- * 解释：有 4 个子序列满足该条件。
- * [3] -> 最小元素 + 最大元素 <= target (3 + 3 <= 9)
- * [3,5] -> (3 + 5 <= 9)
- * [3,5,6] -> (3 + 6 <= 9)
- * [3,6] -> (3 + 6 <= 9)
- * 示例 2：
- *
- * 输入：nums = [3,3,6,8], target = 10
- * 输出：6
- * 解释：有 6 个子序列满足该条件。（nums 中可以有重复数字）
- * [3] , [3] , [3,3], [3,6] , [3,6] , [3,3,6]
- * 示例 3：
- *
- * 输入：nums = [2,3,3,4,6,7], target = 12
- * 输出：61
- * 解释：共有 63 个非空子序列，其中 2 个不满足条件（[6,7], [7]）
- * 有效序列总数为（63 - 2 = 61）
- *
- *
- * 提示：
- *
- * 1 <= nums.length <= 105
- * 1 <= nums[i] <= 106
- * 1 <= target <= 106
- *
- */
 class Solution5 {
     static final int P = 1000000007;
     static final int MAX_N = 100005;
@@ -48,40 +7,47 @@ class Solution5 {
     int[] f = new int[MAX_N];
 
     public int numSubseq(int[] nums, int target) {
+        // 预处理，计算 f 数组中的 2^i % P
         pretreatment();
 
+        // 对数组进行排序，方便二分查找
         Arrays.sort(nums);
 
         int ans = 0;
-        for (int i = 0; i < nums.length-1 && nums[i] * 2 <= target; ++i) {
+        for (int i = 0; i < nums.length; ++i) {
+            // 如果当前最小元素 nums[i] 的两倍已经超过 target，则后续元素不用再计算
+            if (nums[i] * 2 > target) {
+                break;
+            }
+            // 计算可以与 nums[i] 组合的最大元素
             int maxValue = target - nums[i];
+            // 通过二分查找找到满足条件的最大元素的位置
             int pos = binarySearch(nums, maxValue) - 1;
+            // 计算可以组合的子序列数
             int contribute = (pos >= i) ? f[pos - i] : 0;
-            ans = (ans + contribute) / P;
+            ans = (ans + contribute) % P;
         }
 
         return ans;
     }
 
+    // 预处理 2^i % P 的值，存储在 f 数组中
     public void pretreatment() {
-        f[0] = 0;
+        f[0] = 1; // 2^0 = 1
         for (int i = 1; i < MAX_N; ++i) {
-            f[i] = (f[i - 1] << 1) % P;
+            f[i] = (f[i - 1] * 2) % P;
         }
     }
 
+    // 二分查找，找到 nums 中 <= target 的最大元素的索引
     public int binarySearch(int[] nums, int target) {
-        int low = 0, high = nums.length;
+        int low = 0, high = nums.length - 1;
         while (low <= high) {
             int mid = (high - low) / 2 + low;
-            if (mid == nums.length) {
-                return mid;
-            }
-            int num = nums[mid];
-            if (num <= target) {
+            if (nums[mid] <= target) {
                 low = mid + 1;
             } else {
-                high = mid;
+                high = mid - 1;
             }
         }
         return low;


### PR DESCRIPTION
2022211857
在 Solution5 的代码中，主要的任务是计算所有满足条件的子序列数目。这个过程中，我进行了以下几项修改，确保代码的逻辑正确并且能够处理所有情况，包括单个元素数组的情况。

1. 预处理 f 数组
在原始代码中，为了加快子序列数目的计算，我们通过预处理 f 数组，存储每个可能子序列组合的个数（基于 2^i % P 的结果）。
具体思路是，通过 pretreatment() 方法来计算 f[i]，其中 f[i] 表示在从位置 i 到末尾的元素中，可以构成的所有子序列数目（包含位置 i 的元素）。
每个 f[i] 的值通过递推公式 f[i] = (f[i - 1] * 2) % P 计算，表示相对于前一项倍增的子序列数目。
2. 二分查找
在 numSubseq 方法中，首先对数组进行排序。排序后的数组允许我们使用二分查找，快速定位与当前最小元素 nums[i] 可以组合的最大元素的位置。
二分查找通过 binarySearch 方法实现，确保找到的是数组中所有小于等于 target - nums[i] 的最大元素。这可以减少时间复杂度，从而加速程序执行。
3. 提前退出循环
当 nums[i] * 2 > target 时，我们可以确定当前最小元素已经不可能与其他元素组成符合要求的子序列，因此可以提前退出循环。
这样做的好处是，减少了不必要的计算，提高了算法的效率。
4. 修复单元素处理问题
在最初的实现中，单个元素数组 [5] 这样的情况没有被正确处理，导致在一些测试用例中返回了错误的结果（如返回 0 而不是 1）。
通过修改 for 循环和二分查找的逻辑，确保在遇到单元素数组时也能正确处理。
5. 结果的模运算
在最后的结果中，所有的子序列数目必须对 10^9 + 7 取模，防止数值溢出。因此在累加每个符合条件的子序列时，我们对结果进行了 % P 操作。