### PR TITLE
Solution 9

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Solution9.java

--- a/.idea/OSSDP-Lab2.iml
+++ b/.idea/OSSDP-Lab2.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <selected-state>
+          <State>
+            <id>用户定义</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="17" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" filepath="$PROJECT_DIR$/.idea/OSSDP-Lab2.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Solution9.java
+++ b/Solution9.java
@@ -84,15 +84,15 @@ class Solution9 {
     }
     // 测试类
     public static void main(String[] args) {
-        Solution9 solution = new Solution9();
+        Solution9 L2022211898_Solution9_Test.java = new Solution9();
         // 示例 1
         int[][] dislikes1 = {{1, 2}, {1, 3}, {2, 4}};
-        System.out.println(solution.possibleBipartition(4, dislikes1)); // 输出 true
+        System.out.println(L2022211898_Solution9_Test.java.possibleBipartition(4, dislikes1)); // 输出 true
         // 示例 2
         int[][] dislikes2 = {{1, 2}, {1, 3}, {2, 3}};
-        System.out.println(solution.possibleBipartition(3, dislikes2)); // 输出 false
+        System.out.println(L2022211898_Solution9_Test.java.possibleBipartition(3, dislikes2)); // 输出 false
         // 示例 3
         int[][] dislikes3 = {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {1, 5}};
-        System.out.println(solution.possibleBipartition(5, dislikes3)); // 输出 false
+        System.out.println(L2022211898_Solution9_Test.java.possibleBipartition(5, dislikes3)); // 输出 false
     }
 }

--- a/Solution9.java
+++ b/Solution9.java
@@ -37,50 +37,62 @@ import java.util.List;
  *
  */
 class Solution9 {
-
     public boolean possibleBipartition(int n, int[][] dislikes) {
-        int[] fa = new int[n + 1];
-        Arrays.fill(fa, -1);
-        List<Integer>[] g = new List[n + 1];
-        for (int i = 0; i < n; ++i) {
-            g[i] = new ArrayList<Integer>();
+        int[] fa = new int[n + 1]; // 并查集，初始化为节点自身
+        for (int i = 1; i <= n; i++) {
+            fa[i] = i; // 初始化为自身
         }
-        for (int[] p : dislikes)
-            g[p[0]].add(p[1]);
-            g[p[1]].add(p[0]);
-        for (int i = 1; i <= n; ++i) {
-            for (int j = 0; j < g[i].size(); ++j) {
-                unit(g[i].get(0), g[i].get(j), fa);
-                if (isconnect(i, g[i].get(j), fa)) {
+        List<Integer>[] g = new List[n + 1];
+        for (int i = 1; i <= n; i++) {
+            g[i] = new ArrayList<>();
+        }
+        for (int[] p : dislikes) {
+            int a = p[0], b = p[1];
+            g[a].add(b);
+            g[b].add(a);
+        }
+        for (int i = 1; i <= n; i++) {
+            for (int neighbor : g[i]) {
+                if (findFa(i, fa) == findFa(neighbor, fa)) {
+                    // 如果已经在同一个集合中，则无法分组
                     return false;
                 }
+                union(i, neighbor, fa);
             }
         }
         return true;
     }
 
-    public void unit(int x, int y, int[] fa) {
-        x = findFa(x, fa);
-        y = findFa(y, fa);
-        if (x == y) {
-            return ;
+    private void union(int x, int y, int[] fa) {
+        int rootX = findFa(x, fa);
+        int rootY = findFa(y, fa);
+        if (rootX != rootY) {
+            // 合并两个集合，这里简单地选择一个集合的代表作为新集合的代表
+            fa[rootX] = -rootY; // 或者 fa[rootY] = -rootX，只要保证它们不同集合并且可以识别即可
+            // 注意：这里使用负数是为了在后续可以通过 fa[i] < 0 来判断 i 是某个集合的代表
         }
-        if (fa[x] <= fa[y]) {
-            int temp = x;
-            x = y;
-            y = temp;
-        }
-        fa[x] += fa[y];
-        fa[y] = x;
     }
 
-    public boolean isconnect(int x, int y, int[] fa) {
-        x = findFa(x, fa);
-        y = findFa(y, fa);
-        return x == y;
+    private int findFa(int x, int[] fa) {
+        if (fa[x] < 0) {
+            // 如果是负数，则已经是代表
+            return x;
+        }
+        // 路径压缩
+        fa[x] = findFa(fa[x], fa);
+        return fa[x];
     }
-
-    public int findFa(int x, int[] fa) {
-        return fa[x] > 0 ? x : (fa[x] = findFa(fa[x], fa));
+    // 测试类
+    public static void main(String[] args) {
+        Solution9 solution = new Solution9();
+        // 示例 1
+        int[][] dislikes1 = {{1, 2}, {1, 3}, {2, 4}};
+        System.out.println(solution.possibleBipartition(4, dislikes1)); // 输出 true
+        // 示例 2
+        int[][] dislikes2 = {{1, 2}, {1, 3}, {2, 3}};
+        System.out.println(solution.possibleBipartition(3, dislikes2)); // 输出 false
+        // 示例 3
+        int[][] dislikes3 = {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {1, 5}};
+        System.out.println(solution.possibleBipartition(5, dislikes3)); // 输出 false
     }
 }


### PR DESCRIPTION
个人学号为2022211898
fa 数组用于并查集，其中 fa[i] 表示节点 i 的父节点。初始化时，每个节点的父节点应该是它自己（表示它是一个独立的集合），但要用一个负数来表示这个节点是集合的代表（通常使用 -1 表示根节点，但在这里我们稍微改变一下，用节点编号的正数表示它是自己的代表，并在路径压缩时改为负数来表示已经找到的代表）。然而，初始化使用了 -1，这在路径压缩时会导致混淆。可以简单地使用节点编号本身作为初始值，并在路径压缩时将其改为负数。
循环逻辑：在遍历 dislikes 数组构建图之后，代码尝试对每个节点 i 和它的邻居 g[i].get(j) 进行合并和检查连接性。但是，代码的循环逻辑有误，因为它只检查了第一个邻居，并且试图对同一个邻居进行多次合并和检查。因此应该对每个节点的所有邻居进行迭代，并在每次迭代中只进行一次合并和检查。
图的构建：图的构建是正确的，但是，由于 dislikes 数组中的每对不喜欢的人都是双向的，因此需要向两个方向添加边。