### PR TITLE
Solution8修改

### DIFF
--- a/L2022211884_8_Test.java
+++ b/L2022211884_8_Test.java
@@ -1,0 +1,108 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.check_maven.Solution8;
+public class L2022211884_8_Test {
+
+    /**
+     * 测试用例设计的总体原则:
+     * 我们基于等价类划分原则进行测试用例的设计。
+     * - 等价类1: 输入为正常的网格，存在多个岛屿。
+     * - 等价类2: 输入为空网格，返回0。
+     * - 等价类3: 输入为全部水域的网格，返回0。
+     * - 等价类4: 输入为一个完整的岛屿，返回1。
+     * - 边界测试: 只有一行或者一列的网格。
+     */
+
+    /**
+     * 测试方法1: 测试正常的多个岛屿情况
+     * 测试用例: 4x5网格，期望结果为3
+     */
+    @Test
+    public void testMultipleIslands() {
+        char[][] grid = {
+                {'1', '1', '0', '0', '0'},
+                {'1', '1', '0', '0', '0'},
+                {'1', '0', '1', '0', '0'},
+                {'0', '0', '0', '1', '1'}
+        };
+        Solution8 solution = new Solution8();
+        int result = solution.numIslands(grid);
+        assertEquals(3, result, "4x5的网格应有3个岛屿");
+    }
+
+    /**
+     * 测试方法2: 测试空网格情况
+     * 测试用例: 输入为空，期望结果为0
+     */
+    @Test
+    public void testEmptyGrid() {
+        char[][] grid = new char[][]{};
+        Solution8 solution = new Solution8();
+        int result = solution.numIslands(grid);
+        assertEquals(0, result, "空网格应返回0个岛屿");
+    }
+
+    /**
+     * 测试方法3: 测试只有水的情况
+     * 测试用例: 3x3全水域网格，期望结果为0
+     */
+    @Test
+    public void testAllWater() {
+        char[][] grid = {
+                {'0', '0', '0'},
+                {'0', '0', '0'},
+                {'0', '0', '0'}
+        };
+        Solution8 solution = new Solution8();
+        int result = solution.numIslands(grid);
+        assertEquals(0, result, "全水域的网格应返回0个岛屿");
+    }
+
+    /**
+     * 测试方法4: 测试一个完整岛屿的情况
+     * 测试用例: 3x3的单个岛屿，期望结果为1
+     */
+    @Test
+    public void testSingleIsland() {
+        char[][] grid = {
+                {'1', '1', '1'},
+                {'1', '1', '1'},
+                {'1', '1', '1'}
+        };
+        Solution8 solution = new Solution8();
+        int result = solution.numIslands(grid);
+        assertEquals(1, result, "单个岛屿的网格应返回1个岛屿");
+    }
+
+    /**
+     * 测试方法5: 边界测试 - 一行的网格
+     * 测试用例: 1x5的网格，期望结果为2
+     */
+    @Test
+    public void testOneRowGrid() {
+        char[][] grid = {
+                {'1', '0', '1', '0', '1'}
+        };
+        Solution8 solution = new Solution8();
+        int result = solution.numIslands(grid);
+        assertEquals(3, result, "1x5的网格应返回3个岛屿");
+    }
+
+    /**
+     * 测试方法6: 边界测试 - 一列的网格
+     * 测试用例: 5x1的网格，期望结果为2
+     */
+    @Test
+    public void testOneColumnGrid() {
+        char[][] grid = {
+                {'1'},
+                {'0'},
+                {'1'},
+                {'0'},
+                {'1'}
+        };
+        Solution8 solution = new Solution8();
+        int result = solution.numIslands(grid);
+        assertEquals(3, result, "5x1的网格应返回3个岛屿");
+    }
+}

--- a/Solution8.java
+++ b/Solution8.java
@@ -1,3 +1,5 @@
+package com.check_maven;
+
 /**
  * @description:
  *
@@ -37,33 +39,57 @@
  * grid[i][j] 的值为 '0' 或 '1'
  *
  */
-class Solution8 {
+public class Solution8 {
+    public static void main(String[] args) {
+        // 你的测试代码可以放在这里
+        char[][] grid = {
+                {'1', '1', '0', '0', '0'},
+                {'1', '1', '0', '0', '0'},
+                {'1', '0', '1', '0', '0'},
+                {'0', '0', '0', '1', '1'}
+        };
+
+        Solution8 solution = new Solution8();
+        int numIslands = solution.numIslands(grid);
+        System.out.println("岛屿数量: " + numIslands);
+    }
+
     void dfs(char[][] grid, int r, int c) {
         int nr = grid.length;
         int nc = grid[0].length;
 
-        if (r < 0 || c > 0 || r >= nr || c >= nc || grid[r][c] == '0') {
+        // 判断是否越界或者是否遇到水
+        if (r < 0 || c < 0 || r >= nr || c >= nc || grid[r][c] == '0') {
             return;
         }
-        grid[r][c] = '1';
-        dfs(grid, r - 1, c);
-        dfs(grid, r + 1, c);
-        dfs(grid, r, c - 1);
-        dfs(grid, r, c + 1);
+
+        // 将当前陆地格子标记为 '0'，表示已经访问过
+        grid[r][c] = '0';
+
+        // 深度优先搜索，上下左右四个方向
+        dfs(grid, r - 1, c); // 上
+        dfs(grid, r + 1, c); // 下
+        dfs(grid, r, c - 1); // 左
+        dfs(grid, r, c + 1); // 右
     }
 
     public int numIslands(char[][] grid) {
-        if (grid == null || grid.length <= 1) {
+        if (grid == null || grid.length == 0) {
             return 0;
         }
 
         int nr = grid.length;
         int nc = grid[0].length;
         int num_islands = 0;
+
+        // 遍历整个网格
         for (int r = 0; r < nr; ++r) {
-            for (int c = 0; r < nc; ++c) {
+            for (int c = 0; c < nc; ++c) {
+                // 如果遇到陆地格子
                 if (grid[r][c] == '1') {
+                    // 统计岛屿数量
                     ++num_islands;
+                    // 使用DFS将整个岛屿标记为已经访问过
                     dfs(grid, r, c);
                 }
             }


### PR DESCRIPTION
学号：2022211884
修改思路：
1. 越界判断条件的修正
原错误代码：
if (r < 0 || c > 0 || r >= nr || c >= nc || grid[r][c] == '0') {
    return;
}
修改后的代码：
if (r < 0 || c < 0 || r >= nr || c >= nc || grid[r][c] == '0') {
    return;
}
解释：
- 原代码中的 `c > 0` 是错误的，应该是 `c < 0`。因为在网格中，我们需要确保列索引不越界，`c` 必须是大于等于 0 的，`c > 0` 意味着只要列索引不是负数，它就不会被判定为越界，这显然是不正确的。
- 修改后的判断条件确保了 `r` 和 `c` 都不越界，列索引 `c` 小于 0 时会触发越界返回。

2. 深度优先搜索 (DFS) 中标记已访问过的陆地
原错误代码：
grid[r][c] = '1';
修改后的代码：
grid[r][c] = '0';
解释：
- 在原代码中，访问过的陆地格子没有正确标记。原代码将访问过的陆地格子标记为 `'1'`，这样会导致深度优先搜索（DFS）无法停止，进入死循环或重复访问相同的陆地。
- 修改后的代码通过将访问过的陆地标记为 `'0'`，确保它不会被再次访问。这是深度优先搜索（DFS）中的一个常见做法，通过“淹没”已经访问过的格子来避免重复计算同一块岛屿。

 3. 双层循环中列索引条件的修正
原错误代码：
for (int c = 0; r < nc; ++c) {
修改后的代码：
for (int c = 0; c < nc; ++c) {
解释：
- 原代码中，第二层循环的列索引条件使用了错误的变量 `r < nc`。这将导致列循环条件不正确，程序无法正确遍历列。
- 修改后的代码使用正确的列索引 `c < nc`，确保在遍历每一行时，列循环的条件是正确的，从而确保完整遍历网格。

4. 边界情况的检查
修改后的代码：
if (grid == null || grid.length == 0) {
    return 0;
}
 解释：
- 这个修改是为了处理特殊的边界情况，例如传入的 `grid` 为 `null` 或者为空数组时，程序可以立即返回 0，避免不必要的错误和处理。
- 原始代码中可能遗漏了这个边界情况的处理，导致程序可能在处理空数组时出错。

5. 网格遍历和岛屿计数
解释：
- 在修改后的代码中，正确遍历网格的每一个元素，当遇到 `'1'`（即陆地）时，调用深度优先搜索（DFS）将连接的所有陆地都标记为 `'0'`，这样当程序遍历到同一块岛屿的其他部分时，不会重复计数。
- 代码中使用 `++num_islands` 来记录每次遇到新岛屿时增加的岛屿数量，最后返回 `num_islands` 作为结果。

总结：
修改后的代码主要解决了以下几个关键问题：
1. 修正了越界判断中的错误，确保正确处理列索引的越界情况。
2. 正确标记访问过的陆地，避免重复访问或进入死循环。
4. 修正了列索引循环条件的变量，确保网格被正确遍历。
5. 处理边界情况，避免输入空网格时程序崩溃。

这些修改使得代码可以正确地统计二维网格中的岛屿数量。