### PR TITLE
Solution9

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/OSSDP-Lab2.iml" filepath="$PROJECT_DIR$/OSSDP-Lab2.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/L2022113318_9_Test.java
+++ b/L2022113318_9_Test.java
@@ -1,0 +1,152 @@
+
+import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 测试用例设计原则
+ * 1. 等价类划分：
+ * 将输入数据分成有效和无效的等价类，以减少测试用例的数量。例如，对于 n 人，可以将 n 分为 1，和大于 1 的不同情况
+ * 2. 边界值分析：
+ * 测试输入的边界值，如 n = 1 、 n = 2 以及最大值 n = 2000 。
+ * 3. 特例测试：
+ * 包括特定的组合情况，比如所有人相互之间都不喜欢、部分人不喜欢等。
+ * 4. 组合测试：
+ * 测试不同的组合情况，比如大规模的输入、复杂的关系等，以确保代码在不同情况下的稳定性
+ */
+public class L2022113318_9_Test {
+    private final Solution9 solution = new Solution9();
+
+    /**
+     * 测试目的：测试基本功能，确保简单用例能够正确处理。
+     * 用例1: n = 4, dislikes = [[1, 2], [1, 3], [2, 4]]
+     * 预期输出: true
+     * 解释: 可以分成两组：[1, 4] 和 [2, 3]
+     * 用例2: n = 3, dislikes = [[1, 2], [1, 3], [2, 3]]
+     * 预期输出: false
+     * 解释: 无法将所有人分成两组
+     * 用例3: n = 5, dislikes = [[1, 2], [2, 3], [3, 4], [4, 5], [1, 5]]
+     * 预期输出: false
+     * 解释: 存在冲突，无法分组
+     */
+    @Test
+    void testBasicFunctionality() {
+        assertTrue(solution.possibleBipartition(4, new int[][]{{1, 2}, {1, 3}, {2, 4}})); // true
+        assertFalse(solution.possibleBipartition(3, new int[][]{{1, 2}, {1, 3}, {2, 3}})); // false
+        assertFalse(solution.possibleBipartition(5, new int[][]{{1, 2}, {2, 3}, {3, 4}, {4, 5}, {1, 5}})); // false
+    }
+
+    /**
+     * 测试目的：测试边界条件，验证函数在极端情况下的表现。
+     * 用例4: n = 1 , dislikes = []
+     * 预期输出: true
+     * 解释: 只有一个人，自然可以分组
+     * 用例5: n = 2 , dislikes = [[1, 2]]
+     * 预期输出: true
+     * 解释: 可以分成两组：[1] 和 [2]
+     */
+    @Test
+    void testBoundaryConditions() {
+        assertTrue(solution.possibleBipartition(1, new int[][]{})); // true
+        assertTrue(solution.possibleBipartition(2, new int[][]{{1, 2}})); // true
+    }
+
+    /**
+     * 测试目的：测试大规模输入，确保在复杂情况下程序的稳定性。
+     * 用例6: n = 2000 , dislikes = []
+     * 预期输出: true
+     * 解释: 没有冲突，所有人都可以被分成两组
+     * 用例7: n = 2000 , dislikes = [[1, 2], [3, 4], ..., [1999, 2000]]
+     * 预期输出: true
+     * 解释: 可以将每对不喜欢的人放在不同的组
+     */
+    @Test
+    void testLargeInputs() {
+        assertTrue(solution.possibleBipartition(2000, new int[][]{})); // true
+        assertTrue(solution.possibleBipartition(2000, generateDislikes(2000))); // true
+    }
+
+    private int[][] generateDislikes(int n) {
+        int[][] dislikes = new int[n - 1][2];
+        for (int i = 1; i < n; i++) {
+            dislikes[i - 1][0] = i;
+            dislikes[i - 1][1] = i + 1;
+        }
+        return dislikes;
+    }
+
+    /**
+     * 测试目的：测试复杂的冲突情况，确保函数能正确识别不能分组的情况。
+     * 用例8: n = 6 , dislikes = [[1, 2], [2, 4], [4, 1]]
+     * 预期输出: false
+     * 解释: 存在环状的冲突，无法分组
+     * 用例9: n = 6 , dislikes = [[1, 2], [2, 3], [3, 4], [4, 5], [1, 6]]
+     * 预期输出: true
+     * 解释: 可以分成两组，例如：[1, 3, 5] 和 [2, 4, 6]
+     */
+    @Test
+    void testComplexConflict() {
+        assertFalse(solution.possibleBipartition(6, new int[][]{{1, 2}, {2, 4},  {4, 1}})); // false
+        assertTrue(solution.possibleBipartition(6, new int[][]{{1, 2}, {2, 3}, {3, 4}, {4, 5}, {1, 6}})); // true
+    }
+
+
+
+    /**
+     * 测试目的：测试完全互相不喜欢的情况，确保能返回正确结果。
+     * 用例10: n = 3 , dislikes = [[1, 2], [1, 3], [2, 3]]
+     * 预期输出: false
+     * 解释: 任意两个之间都无法在同一组
+     */
+    @Test
+    void testAllDislikeEachOther() {
+        assertFalse(solution.possibleBipartition(3, new int[][]{{1, 2}, {1, 3}, {2, 3}})); // false
+    }
+
+    /**
+     * 测试目的：测试具有环状关系的情况，确保能正确识别冲突。
+     * 用例11: n = 5 , dislikes = [[1, 2], [2, 3]，, [3, 4]，, [4, 5]，, [5, 1]]
+     * 预期输出: false
+     * 解释: 首尾相连的环形不可能分为两组
+     */
+    @Test
+    void testCircularDislikes() {
+        assertFalse(solution.possibleBipartition(5, new int[][]{{1, 2}, {2, 3}, {3, 4}, {4, 5},{1, 5}})); // false
+    }
+
+    /**
+     * 测试目的：测试复杂组合，不同的冲突情况。
+     * 用例12: n = 6 , dislikes = [[1, 2], [1, 3], [4, 5], [2, 4]]
+     * 预期输出: true
+     * 解释: 可以分成两组，例如：[1, 4] 和 [2, 3, 5]
+     * 用例13: n = 6 , dislikes = [[1, 2],  [3, 4],  [5, 6]]
+     * 预期输出: true
+     * 解释: 可以分成两组，例如：[1, 3, 5] 和 [2, 4, 6]
+     */
+    @Test
+    void testComplexCombinations() {
+        assertTrue(solution.possibleBipartition(6, new int[][]{{1, 2}, {1, 3}, {4, 5}, {2, 4}})); // true
+        assertTrue(solution.possibleBipartition(6, new int[][]{{1, 2}, {3, 4}, {5, 6}})); // true
+    }
+
+    /**
+     * 测试目的：测试人对自己不喜欢的情况。
+     * 用例14: n = 2 , dislikes = [[1, 1]]
+     * 预期输出: false
+     * 解释: 自己不喜欢自己，放到哪里都是错
+     */
+    @Test
+    void testSelfDislike() {
+        assertFalse(solution.possibleBipartition(2, new int[][]{{1, 1}})); // false
+    }
+
+    /**
+     * 测试目的：测试无冲突的全连接图。
+     * 用例15: n = 4 , dislikes = [[1, 2],  [3, 4],  [2, 3]]
+     * 预期输出: true
+     * 解释: 可以分成两组，例如：[1, 3] 和 [2, 4]
+     */
+    @Test
+    void testFullyConnectedWithoutConflict() {
+        assertTrue(solution.possibleBipartition(4, new int[][]{{1, 2}, {3, 4}, {2, 3}})); // true
+    }
+}

--- a/OSSDP-Lab2.iml
+++ b/OSSDP-Lab2.iml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.1/junit-4.13.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/Solution9.java
+++ b/Solution9.java
@@ -1,6 +1,4 @@
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 /**
  * @description:
@@ -39,31 +37,57 @@ import java.util.List;
 class Solution9 {
 
     public boolean possibleBipartition(int n, int[][] dislikes) {
-        int[] fa = new int[n + 1];
-        Arrays.fill(fa, -1);
         List<Integer>[] g = new List[n + 1];
-        for (int i = 0; i < n; ++i) {
-            g[i] = new ArrayList<Integer>();
+        for (int i = 1; i <= n; ++i) {
+            g[i] = new ArrayList<>();
         }
-        for (int[] p : dislikes)
+
+        // 构建邻接表
+        for (int[] p : dislikes) {
             g[p[0]].add(p[1]);
             g[p[1]].add(p[0]);
+        }
+
+        // 颜色数组，0: 未染色, 1: 组1, -1: 组2
+        int[] colors = new int[n + 1];
+
+        // 遍历每个人
         for (int i = 1; i <= n; ++i) {
-            for (int j = 0; j < g[i].size(); ++j) {
-                unit(g[i].get(0), g[i].get(j), fa);
-                if (isconnect(i, g[i].get(j), fa)) {
-                    return false;
+            if (colors[i] == 0) { // 还未访问
+                if (!bfs(i, 1, g, colors)) { // 从未访问的节点开始 BFS
+                    return false; // 如果发现冲突，返回 false
                 }
             }
         }
-        return true;
+        return true; // 所有人都可以被分成两组
+    }
+
+    private boolean bfs(int start, int color, List<Integer>[] g, int[] colors) {
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(start);
+        colors[start] = color; // 将起始节点染为组1
+
+        while (!queue.isEmpty()) {
+            int current = queue.poll();
+
+            for (int neighbor : g[current]) {
+                if (colors[neighbor] == 0) { // 如果邻居未被染色
+                    colors[neighbor] = -colors[current]; // 给邻居染上相反的颜色
+                    queue.offer(neighbor);
+                } else if (colors[neighbor] == colors[current]) {
+                    return false; // 如果邻居与当前节点颜色相同，返回 false
+                }
+            }
+        }
+
+        return true; // BFS 完成，未发现冲突
     }
 
     public void unit(int x, int y, int[] fa) {
         x = findFa(x, fa);
         y = findFa(y, fa);
         if (x == y) {
-            return ;
+            return;
         }
         if (fa[x] <= fa[y]) {
             int temp = x;
@@ -81,6 +105,6 @@ class Solution9 {
     }
 
     public int findFa(int x, int[] fa) {
-        return fa[x] > 0 ? x : (fa[x] = findFa(fa[x], fa));
+        return fa[x] < 0 ? x : (fa[x] = findFa(fa[x], fa));
     }
 }

--- a/out/production/OSSDP-Lab2/.idea/.gitignore
+++ b/out/production/OSSDP-Lab2/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/out/production/OSSDP-Lab2/.idea/compiler.xml
+++ b/out/production/OSSDP-Lab2/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/out/production/OSSDP-Lab2/.idea/misc.xml
+++ b/out/production/OSSDP-Lab2/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenRunner">
+    <option name="jreName" value="11" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/out/production/OSSDP-Lab2/.idea/modules.xml
+++ b/out/production/OSSDP-Lab2/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/OSSDP-Lab2.iml" filepath="$PROJECT_DIR$/OSSDP-Lab2.iml" />
+    </modules>
+  </component>
+</project>

--- a/out/production/OSSDP-Lab2/.idea/vcs.xml
+++ b/out/production/OSSDP-Lab2/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/out/production/OSSDP-Lab2/OSSDP-Lab2.iml
+++ b/out/production/OSSDP-Lab2/OSSDP-Lab2.iml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.1/junit-4.13.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/out/production/OSSDP-Lab2/README.md
+++ b/out/production/OSSDP-Lab2/README.md
@@ -1,0 +1,1 @@
+# OSSDP-Lab2


### PR DESCRIPTION
学号：2022113318
思路：
1.邻接表初始化
在初始化邻接表 g 时，使用了 for (int i = 0; i < n; ++i) ，导致索引越界。将索引修改为从 1 到 n 。
2. 邻接表构建
在添加边的部分， g[p[0]].add(p[1]); 和 g[p[1]].add(p[0]); 没有用 {} 包裹住，只有第一行代码被视为循环体的一部分，第二行代码会在外部执行，会报语法错误。
3. 并查集逻辑
unit 方法没有考虑到如果 x 和 y 处于不同的组应该如何处理。并查集的实现需要确保连接不同组时能够正确区分。findFa 方法的逻辑也有问题， fa[x] > 0 的判断应该是 fa[x] < 0 ，因为 fa 数组的初始值为 -1 ，用以表示每个节点的根节点和大小。
4. 遍历逻辑
在遍历每个人时，仅仅根据 g[i].get(0) 来调用 unit 方法是不够的，应该对所有的邻接节点进行处理，而不仅仅是第一个。
5. 无返回值的DFS/BFS
代码没有使用DFS或BFS进行遍历来确保可以将人分为两组，导致效率低下。于是增加了bfs方法来遍历。