### PR TITLE
5

### DIFF
--- a/L2022112008_5_test.java
+++ b/L2022112008_5_test.java
@@ -1,0 +1,30 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class L2022112008_5_test {
+
+    /**
+     * Test case design principles:
+     * 1. Equivalence partitioning: Divide the input array and target value into different equivalence classes to ensure representative test cases for each class.
+     * 2. Boundary value analysis: Test boundary cases such as the minimum value, maximum value, and empty array.
+     * 3. Special case testing: Test arrays with duplicate elements, arrays where all elements are the same, etc.
+     */
+
+    @Test
+    public void testNumSubseq() {
+        Solution5 solution = new Solution5();
+
+        // Equivalence partitioning tests
+        assertEquals(4, solution.numSubseq(new int[]{3, 5, 6, 7}, 9));
+        assertEquals(6, solution.numSubseq(new int[]{3, 3, 6, 8}, 10));
+        assertEquals(61, solution.numSubseq(new int[]{2, 3, 3, 4, 6, 7}, 12));
+
+        // Boundary value analysis tests
+        assertEquals(0, solution.numSubseq(new int[]{}, 5)); // Empty array
+        assertEquals(0, solution.numSubseq(new int[]{10}, 5)); // Single element greater than target
+
+        // Special case tests
+        assertEquals(15, solution.numSubseq(new int[]{1, 1, 1, 1}, 2)); // All elements the same
+        assertEquals(0, solution.numSubseq(new int[]{10, 20, 30}, 5)); // All elements greater than target
+    }
+}

--- a/Solution5.java
+++ b/Solution5.java
@@ -41,49 +41,43 @@ import java.util.Arrays;
  * 1 <= target <= 106
  *
  */
+import java.util.Arrays;
+
 class Solution5 {
-    static final int P = 1000000007;
+    static final int P = 1000000007; // 模数
     static final int MAX_N = 100005;
 
-    int[] f = new int[MAX_N];
+    int[] f = new int[MAX_N]; // 存储 2 的幂次结果
 
     public int numSubseq(int[] nums, int target) {
+        // 预处理 2 的幂次
         pretreatment();
 
+        // 将数组排序
         Arrays.sort(nums);
 
         int ans = 0;
-        for (int i = 0; i < nums.length-1 && nums[i] * 2 <= target; ++i) {
-            int maxValue = target - nums[i];
-            int pos = binarySearch(nums, maxValue) - 1;
-            int contribute = (pos >= i) ? f[pos - i] : 0;
-            ans = (ans + contribute) / P;
+        int left = 0, right = nums.length - 1;
+
+        // 双指针遍历
+        while (left <= right) {
+            if (nums[left] + nums[right] <= target) {
+                // 从 left 到 right 的子序列数为 f[right - left]
+                ans = (ans + f[right - left]) % P;
+                left++; // 移动左指针，扩大子序列范围
+            } else {
+                right--; // 移动右指针，缩小最大值
+            }
         }
 
         return ans;
     }
 
+    // 计算 2 的幂次
     public void pretreatment() {
-        f[0] = 0;
+        f[0] = 1;
         for (int i = 1; i < MAX_N; ++i) {
-            f[i] = (f[i - 1] << 1) % P;
+            f[i] = (f[i - 1] * 2) % P;
         }
-    }
-
-    public int binarySearch(int[] nums, int target) {
-        int low = 0, high = nums.length;
-        while (low <= high) {
-            int mid = (high - low) / 2 + low;
-            if (mid == nums.length) {
-                return mid;
-            }
-            int num = nums[mid];
-            if (num <= target) {
-                low = mid + 1;
-            } else {
-                high = mid;
-            }
-        }
-        return low;
     }
 }


### PR DESCRIPTION
2022112008	
1.	二分查找的简化：在这里通过双指针 (left 和 right) 遍历数组，避免了不必要的二分查找。
2.	取模操作修正：使用 % P 而不是 / P，确保 ans 始终保持在范围内。
3.	预处理数组 f 初始化修正：f[0] = 1，以正确表示 2 的幂次，并在后续处理中积累符合条件的子序列数量。