### PR TITLE
Fix Solution3

### DIFF
--- a/L2023111966_3_Test.java
+++ b/L2023111966_3_Test.java
@@ -1,38 +1,68 @@
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
-public class L123456_3_Test {
-    
+public class L2023111966_3_Test {
+
+    /**
+     * 测试用例设计原则：等价类划分原则
+     * 测试目标：验证最大整除子集算法在正常输入下的表现。
+     */
     @Test
-    public void testSortWithPositiveAndNegativeNumbers() {
-        int[] input = {3, -1, 2, -5, 0};
-        int[] expected = {-5, -1, 0, 2, 3};
-        SortAlgorithm.sort(input);
-        assertArrayEquals(expected, input);
+    public void testLargestDivisibleSubset() {
+        Solution3 solution = new Solution3();
+
+        // 输入：{1, 2, 3}
+        int[] input1 = {1, 2, 3};
+        List<Integer> expected1 = List.of(1, 2); // 最大整除子集是 [1, 2]
+        assertEquals(expected1, solution.largestDivisibleSubset(input1));
+
+        // 输入：{1, 2, 4, 8}
+        int[] input2 = {1, 2, 4, 8};
+        List<Integer> expected2 = List.of(1, 2, 4, 8); // 最大整除子集是 [1, 2, 4, 8]
+        assertEquals(expected2, solution.largestDivisibleSubset(input2));
+
+        // 输入：{1, 3, 9, 27}
+        int[] input3 = {1, 3, 9, 27};
+        List<Integer> expected3 = List.of(1, 3, 9, 27); // 最大整除子集是 [1, 3, 9, 27]
+        assertEquals(expected3, solution.largestDivisibleSubset(input3));
+
+        // 输入：{5, 10, 20, 30}
+        int[] input4 = {5, 10, 20, 30};
+        List<Integer> expected4 = List.of(5, 10, 20); // 最大整除子集是 [5, 10, 20]
+        assertEquals(expected4, solution.largestDivisibleSubset(input4));
     }
 
+    /**
+     * 测试用例设计原则：边界值分析
+     * 测试目标：验证算法对空数组和数组长度为1的情况的处理。
+     */
     @Test
-    public void testSortEmptyArray() {
-        int[] input = {};
-        int[] expected = {};
-        SortAlgorithm.sort(input);
-        assertArrayEquals(expected, input);
+    public void testEdgeCases() {
+        Solution3 solution = new Solution3();
+
+        // 空数组
+        int[] input1 = {};
+        List<Integer> expected1 = List.of();
+        assertEquals(expected1, solution.largestDivisibleSubset(input1));
+
+        // 只有一个元素的数组
+        int[] input2 = {10};
+        List<Integer> expected2 = List.of(10); // 子集只能包含自己
+        assertEquals(expected2, solution.largestDivisibleSubset(input2));
     }
 
+    /**
+     * 测试用例设计原则：错误推测
+     * 测试目标：验证算法是否能处理重复的元素（题目中没有重复，所以这是个额外的边界测试）
+     */
     @Test
-    public void testSortAlreadySorted() {
-        int[] input = {-5, 0, 2, 3};
-        int[] expected = {-5, 0, 2, 3};
-        SortAlgorithm.sort(input);
-        assertArrayEquals(expected, input);
-    }
+    public void testWithDuplicates() {
+        Solution3 solution = new Solution3();
 
-
-    @Test
-    public void testSortAllSameElements() {
-        int[] input = {5, 5, 5, 5};
-        int[] expected = {5, 5, 5, 5};
-        SortAlgorithm.sort(input);
-        assertArrayEquals(expected, input);
+        // 虽然题目中没有重复元素，但我们可以测试如果有重复元素时的反应
+        int[] input = {1, 2, 2, 4, 8};
+        List<Integer> expected = List.of(1, 2, 4, 8); // 重复元素 2 被忽略
+        assertEquals(expected, solution.largestDivisibleSubset(input));
     }
 }

--- a/L2023111966_3_Test.java
+++ b/L2023111966_3_Test.java
@@ -1,0 +1,38 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class L123456_3_Test {
+    
+    @Test
+    public void testSortWithPositiveAndNegativeNumbers() {
+        int[] input = {3, -1, 2, -5, 0};
+        int[] expected = {-5, -1, 0, 2, 3};
+        SortAlgorithm.sort(input);
+        assertArrayEquals(expected, input);
+    }
+
+    @Test
+    public void testSortEmptyArray() {
+        int[] input = {};
+        int[] expected = {};
+        SortAlgorithm.sort(input);
+        assertArrayEquals(expected, input);
+    }
+
+    @Test
+    public void testSortAlreadySorted() {
+        int[] input = {-5, 0, 2, 3};
+        int[] expected = {-5, 0, 2, 3};
+        SortAlgorithm.sort(input);
+        assertArrayEquals(expected, input);
+    }
+
+
+    @Test
+    public void testSortAllSameElements() {
+        int[] input = {5, 5, 5, 5};
+        int[] expected = {5, 5, 5, 5};
+        SortAlgorithm.sort(input);
+        assertArrayEquals(expected, input);
+    }
+}

--- a/Solution3.java
+++ b/Solution3.java
@@ -1,73 +1,54 @@
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-/**
- * @description:
- *
- * 给你一个由 无重复 正整数组成的集合 nums ，请你找出并返回其中最大的整除子集 answer ，子集中每一元素对 (answer[i], answer[j]) 都应当满足：
- * answer[i] % answer[j] == 0 ，或
- * answer[j] % answer[i] == 0
- * 如果存在多个有效解子集，返回其中任何一个均可。
- *
- *
- *
- * 示例 1：
- *
- * 输入：nums = [1,2,3]
- * 输出：[1,2]
- * 解释：[1,3] 也会被视为正确答案。
- * 示例 2：
- *
- * 输入：nums = [1,2,4,8]
- * 输出：[1,2,4,8]
- *
- *
- * 提示：
- *
- * 1 <= nums.length <= 1000
- * 1 <= nums[i] <= 2 * 109
- * nums 中的所有整数 互不相同
- *
- */
-class Solution3 {
+public class Solution3 {
     public List<Integer> largestDivisibleSubset(int[] nums) {
-        int len = nums.length-1;
+        int len = nums.length;
+        if (len == 0) return new ArrayList<>();
+
+        // 去除重复元素并排序
+        Set<Integer> uniqueNums = new HashSet<>();
+        for (int num : nums) {
+            uniqueNums.add(num);
+        }
+        nums = uniqueNums.stream().mapToInt(Integer::intValue).toArray();
         Arrays.sort(nums);
 
         // 第 1 步：动态规划找出最大子集的个数、最大子集中的最大整数
-        int[] dp = new int[len];
-        Arrays.fill(dp, 1);
-        int maxSize = 1;
-        int maxVal = dp[0];
-        for (int i = 1; i < len; i++) {
-            for (int j = 1; j < i; j++) {
-                // 题目中说「没有重复元素」很重要
-                if (nums[i] % nums[j] == 0) {
-                    dp[i] = Math.max(dp[i], dp[j] + 1);
+        int[] dp = new int[nums.length];
+        int[] prev = new int[nums.length];  // 用来记录链中的前一个元素
+        Arrays.fill(dp, 1);  // 每个元素至少能包含自己
+        Arrays.fill(prev, -1);  // 初始时没有前驱元素
+        int maxSize = 1;  // 最大子集的大小
+        int maxValIndex = 0;  // 最大子集的末尾元素的索引
+
+        for (int i = 1; i < nums.length; i++) {
+            for (int j = 0; j < i; j++) {
+                // 如果 nums[i] 能被 nums[j] 整除且能形成更大的子集
+                if (nums[i] % nums[j] == 0 && dp[i] < dp[j] + 1) {
+                    dp[i] = dp[j] + 1;  // 更新子集大小
+                    prev[i] = j;  // 记录链中的前一个元素
                 }
             }
-
             if (dp[i] > maxSize) {
                 maxSize = dp[i];
-                maxVal = i;
+                maxValIndex = i;  // 更新最大子集末尾的元素索引
             }
         }
 
         // 第 2 步：倒推获得最大子集
-        List<Integer> res = new ArrayList<Integer>();
-        if (maxSize == 1) {
-            res.add(nums[0]);
-            return res;
+        List<Integer> res = new ArrayList<>();
+        while (maxValIndex != -1) {
+            res.add(nums[maxValIndex]);
+            maxValIndex = prev[maxValIndex];  // 通过 prev 数组倒推
         }
 
-        for (int i = len - 1; i >= 0; i--) {
-            if (dp[i] == maxSize && maxVal % nums[i] == 0) {
-                res.add(nums[i]);
-                maxVal = nums[i];
-                maxSize--;
-            }
-        }
+        // 因为是倒推的结果，需要反转
+        Collections.reverse(res);
         return res;
     }
 }


### PR DESCRIPTION
2023111966

在原始代码中，len 被设为 nums.length - 1，这导致了数组在后续的处理过程中没有包含最后一个元素。正确的做法是使用 nums.length，
在原始代码中，dp 数组的初始化存在问题。dp 数组的长度应该与 nums 数组相同，而不是 len。同时 dp 数组的每个元素应该初始化为 1。
原始代码没有处理最大子集的构建。在动态规划过程中，我们需要记录每个元素在最大子集中的前一个元素。
在最大子集末尾元素的索引更新时，原代码使用了错误的索引 maxVal = i，而正确的做法是更新 maxValIndex，并通过它来跟踪当前子集的末尾元素索引。
为了确保返回的子集是正确的，添加了去重的步骤（通过 HashSet）并对数组进行排序。
通过 dp 和 prev 数组的协作，我们能够倒推出最终的最大子集。倒推的过程是从 maxValIndex 开始，通过 prev 数组逐步回溯前驱元素，直到遇到 -1 为止。