### PR TITLE
修复题目5的bug并添加完整测试用例

### DIFF
--- a/L2023112265_5_Test.java
+++ b/L2023112265_5_Test.java
@@ -1,0 +1,190 @@
+/**
+ * 测试类：L2023112265_5_Test
+ *
+ * 测试用例设计总体原则：
+ * 1. 等价类划分：将输入划分为有效等价类和无效等价类
+ *    - 有效等价类：满足条件的各种输入组合
+ *    - 无效等价类：不满足条件的输入情况
+ * 2. 边界值分析：测试输入范围的边界条件
+ *    - 数组长度边界：空数组、单元素数组、多元素数组
+ *    - 数值边界：最小值、最大值、临界值
+ * 3. 错误推测：基于算法特点推测可能错误
+ *    - 排序后的数组处理
+ *    - 二分查找边界情况
+ *    - 大数取模运算
+ * 4. 路径覆盖：确保代码中的所有执行路径都被测试
+ *    - 正常执行路径
+ *    - 异常和边界路径
+ */
+public class L2023112265_5_Test {
+
+    public static void main(String[] args) {
+        System.out.println("=== 开始测试Solution5 ===");
+        System.out.println("学号：2023112265");
+        System.out.println("题目：5");
+        System.out.println();
+
+        int passedTests = 0;
+        int totalTests = 5;
+
+        if (testExample1()) passedTests++;
+        if (testExample2()) passedTests++;
+        if (testExample3()) passedTests++;
+        if (testSingleElement()) passedTests++;
+        if (testAllElementsSatisfied()) passedTests++;
+
+        System.out.println("=== 测试完成 ===");
+        System.out.println("通过测试数：" + passedTests + "/" + totalTests);
+        System.out.println("结果：" + (passedTests == totalTests ? "所有测试通过" : "部分测试失败"));
+    }
+
+    /**
+     * 测试目的：验证题目提供的示例1的正确性
+     * 用到的测试用例：
+     * - 输入：nums = [3,5,6,7], target = 9
+     * - 期望输出：4
+     * - 用例类型：正常情况，中等大小的数组
+     */
+    public static boolean testExample1() {
+        Solution5 solution = new Solution5();
+        int[] nums = {3, 5, 6, 7};
+        int target = 9;
+        int expected = 4;
+        int result = solution.numSubseq(nums, target);
+
+        boolean passed = (result == expected);
+        System.out.println("测试1 - 示例1 " + (passed ? "通过" : "失败"));
+        System.out.println("  输入: nums = [3,5,6,7], target = 9");
+        System.out.println("  期望: " + expected + ", 实际: " + result);
+        if (!passed) {
+            System.out.println("  !!! 测试失败 !!!");
+        }
+        System.out.println();
+        return passed;
+    }
+
+    /**
+     * 测试目的：验证题目提供的示例2的正确性，测试重复元素的处理
+     * 用到的测试用例：
+     * - 输入：nums = [3,3,6,8], target = 10
+     * - 期望输出：6
+     * - 用例类型：包含重复元素的数组
+     */
+    public static boolean testExample2() {
+        Solution5 solution = new Solution5();
+        int[] nums = {3, 3, 6, 8};
+        int target = 10;
+        int expected = 6;
+        int result = solution.numSubseq(nums, target);
+
+        boolean passed = (result == expected);
+        System.out.println("测试2 - 示例2 " + (passed ? "通过" : "失败"));
+        System.out.println("  输入: nums = [3,3,6,8], target = 10");
+        System.out.println("  期望: " + expected + ", 实际: " + result);
+        if (!passed) {
+            System.out.println("  !!! 测试失败 !!!");
+        }
+        System.out.println();
+        return passed;
+    }
+
+    /**
+     * 测试目的：验证题目提供的示例3的正确性，测试较大数组的情况
+     * 用到的测试用例：
+     * - 输入：nums = [2,3,3,4,6,7], target = 12
+     * - 期望输出：61
+     * - 用例类型：较大数组，验证算法效率
+     */
+    public static boolean testExample3() {
+        Solution5 solution = new Solution5();
+        int[] nums = {2, 3, 3, 4, 6, 7};
+        int target = 12;
+        int expected = 61;
+        int result = solution.numSubseq(nums, target);
+
+        boolean passed = (result == expected);
+        System.out.println("测试3 - 示例3 " + (passed ? "通过" : "失败"));
+        System.out.println("  输入: nums = [2,3,3,4,6,7], target = 12");
+        System.out.println("  期望: " + expected + ", 实际: " + result);
+        if (!passed) {
+            System.out.println("  !!! 测试失败 !!!");
+        }
+        System.out.println();
+        return passed;
+    }
+
+    /**
+     * 测试目的：验证边界情况-单元素数组的处理
+     * 用到的测试用例：
+     * - 输入：nums = [5], target = 10
+     * - 期望输出：1
+     * - 用例类型：边界情况，最小非空子序列
+     */
+    public static boolean testSingleElement() {
+        Solution5 solution = new Solution5();
+        int[] nums = {5};
+        int target = 10;
+        int expected = 1;
+        int result = solution.numSubseq(nums, target);
+
+        boolean passed = (result == expected);
+        System.out.println("测试4 - 单元素数组 " + (passed ? "通过" : "失败"));
+        System.out.println("  输入: nums = [5], target = 10");
+        System.out.println("  期望: " + expected + ", 实际: " + result);
+        if (!passed) {
+            System.out.println("  !!! 测试失败 !!!");
+        }
+        System.out.println();
+        return passed;
+    }
+
+    /**
+     * 测试目的：验证所有元素都满足条件的情况
+     * 用到的测试用例：
+     * - 输入：nums = [1,1,1,1], target = 10
+     * - 期望输出：15 (2^4 - 1 = 15)
+     * - 用例类型：特殊情况，验证组合数学计算
+     */
+    public static boolean testAllElementsSatisfied() {
+        Solution5 solution = new Solution5();
+        int[] nums = {1, 1, 1, 1};
+        int target = 10;
+        int expected = 15;
+        int result = solution.numSubseq(nums, target);
+
+        boolean passed = (result == expected);
+        System.out.println("测试5 - 全满足条件 " + (passed ? "通过" : "失败"));
+        System.out.println("  输入: nums = [1,1,1,1], target = 10");
+        System.out.println("  期望: " + expected + ", 实际: " + result);
+        if (!passed) {
+            System.out.println("  !!! 测试失败 !!!");
+        }
+        System.out.println();
+        return passed;
+    }
+
+    /**
+     * 测试目的：验证边界情况-无满足条件的子序列
+     * 用到的测试用例：
+     * - 输入：nums = [10,10,10,10], target = 5
+     * - 期望输出：0
+     * - 用例类型：边界情况，验证算法鲁棒性
+     */
+    public static boolean testNoElementsSatisfied() {
+        Solution5 solution = new Solution5();
+        int[] nums = {10, 10, 10, 10};
+        int target = 5;
+        int expected = 0;
+        int result = solution.numSubseq(nums, target);
+
+        boolean passed = (result == expected);
+        System.out.println("测试6 - 无满足条件 " + (passed ? "通过" : "失败"));
+        System.out.println("  输入: nums = [10,10,10,10], target = 5");
+        System.out.println("  期望: " + expected + ", 实际: " + result);
+        if (!passed) {
+            System.out.println("  !!! 测试失败 !!!");
+        }
+        System.out.println();
+        return passed;
+    }
+}

--- a/Solution5.java
+++ b/Solution5.java
@@ -41,44 +41,45 @@ import java.util.Arrays;
  * 1 <= target <= 106
  *
  */
+
 class Solution5 {
     static final int P = 1000000007;
     static final int MAX_N = 100005;
 
     int[] f = new int[MAX_N];
-
     public int numSubseq(int[] nums, int target) {
         pretreatment();
 
         Arrays.sort(nums);
 
         int ans = 0;
-        for (int i = 0; i < nums.length-1 && nums[i] * 2 <= target; ++i) {
+        for (int i = 0; i < nums.length; i++) {
+            if (nums[i] * 2 > target) {
+                break;
+            }
             int maxValue = target - nums[i];
-            int pos = binarySearch(nums, maxValue) - 1;
-            int contribute = (pos >= i) ? f[pos - i] : 0;
-            ans = (ans + contribute) / P;
+            int pos = binarySearch(nums, maxValue);
+            if (pos > i) {
+                int contribute = f[pos - i - 1];
+                ans = (ans + contribute) % P;
+            }
         }
 
         return ans;
     }
 
     public void pretreatment() {
-        f[0] = 0;
+        f[0] = 1;
         for (int i = 1; i < MAX_N; ++i) {
-            f[i] = (f[i - 1] << 1) % P;
+            f[i] = (f[i - 1] * 2) % P;
         }
     }
 
     public int binarySearch(int[] nums, int target) {
         int low = 0, high = nums.length;
-        while (low <= high) {
-            int mid = (high - low) / 2 + low;
-            if (mid == nums.length) {
-                return mid;
-            }
-            int num = nums[mid];
-            if (num <= target) {
+        while (low < high) {
+            int mid = low + (high - low) / 2;
+            if (nums[mid] <= target) {
                 low = mid + 1;
             } else {
                 high = mid;


### PR DESCRIPTION
**学号：2023112265
修改题目号：5**

**修改思路：**
1. **修复f数组初始化错误**
   - 原代码：`f[0] = 0`
   - 修复：`f[0] = 1`（正确表示2^0 = 1）
2. **修复遍历条件不完整**
   - 原代码：`i < nums.length-1`会漏掉最后一个元素
   - 修复：完整遍历并在内部判断退出条件
3. **修复贡献计算逻辑**
   - 原代码：`f[pos - i]`
   - 修复：`f[pos - i - 1]`
4. **修复取模操作错误**
   - 原代码：使用除法`/ P`
   - 修复：使用取模`% P`
5. **优化一些逻辑**
   - 修改了一些代码以提高可读性